### PR TITLE
Remove binary level 5 and 6 maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Os recursos, como sprites e áudio, estão localizados no diretório `res/`, enq
 
 - **Estados do jogo** – O jogo alterna entre os estados `MENU`, `NORMAL` e `GAMEOVER`. O menu principal permite iniciar ou carregar partidas, o estado normal controla o loop de jogo e, ao zerar a vida do jogador, o estado de game over exibe a tela de reinício.【F:src/com/traduvertgames/main/Game.java†L53-L154】【F:src/com/traduvertgames/main/Menu.java†L21-L103】
 - **Loop principal** – O método `run` mantém o jogo atualizado a 60 ticks por segundo, chamando `update()` para lógica e `render()` para desenhar o cenário, entidades, UI e mensagens contextuais.【F:src/com/traduvertgames/main/Game.java†L207-L312】
-- **Progressão de fases** – Ao eliminar todos os inimigos do nível atual, um novo mapa (`level1.png` a `level4.png`) é carregado e, após o último nível, o jogo aumenta os atributos máximos do jogador para partidas estendidas.【F:src/com/traduvertgames/main/Game.java†L115-L154】
+- **Progressão de fases** – Ao eliminar todos os inimigos do nível atual, um novo mapa (`level1.png` a `level4.png`) é carregado. Após o último nível, o jogo aumenta os atributos máximos do jogador para partidas estendidas.【F:src/com/traduvertgames/main/Game.java†L160-L187】
 
 ## Controles e interações
 
@@ -31,8 +31,8 @@ Os recursos, como sprites e áudio, estão localizados no diretório `res/`, enq
 ## Itens e recursos
 
 - **Vida, mana e munição** – O jogador possui barras máximas configuradas dinamicamente; pacotes de vida (`LifePack`) e armas (`Weapon`) são coletados via colisão para restaurar recursos.【F:src/com/traduvertgames/entities/Player.java†L19-L118】【F:src/com/traduvertgames/entities/Entity.java†L109-L194】
-- **Projéteis** – Há dois tipos de disparo (`Bullet` e `BulletShoot`) com atualizações e renderização independentes, mantendo o combate ativo na tela.【F:src/com/traduvertgames/entities/Bullet.java†L5-L12】【F:src/com/traduvertgames/entities/BulletShoot.java†L10-L41】
-- **Inimigos** – A IA usa A* para seguir o jogador, atacando quando em alcance e contabilizando eliminações para progressão de nível.【F:src/com/traduvertgames/entities/Enemy.java†L13-L164】
+- **Projéteis** – Há dois tipos de disparo (`Bullet` e `BulletShoot`) com atualizações e renderização independentes; os disparos energizados (`BulletShoot`) agora também são utilizados pelos inimigos para ataques à distância.【F:src/com/traduvertgames/entities/Bullet.java†L5-L12】【F:src/com/traduvertgames/entities/BulletShoot.java†L12-L52】
+- **Inimigos** – A IA intercala patrulha, perseguição com recálculo dinâmico de caminhos, flanqueia o jogador e dispara projéteis sempre que há linha de visão, contabilizando eliminações para avançar de fase.【F:src/com/traduvertgames/entities/Enemy.java†L28-L370】
 
 ## Sistema de salvamento
 
@@ -42,7 +42,7 @@ O jogo grava dados como vida, mana, inimigos derrotados e fase atual em `save.tx
 
 - **HUD** – A classe `UI` desenha barras e textos com vida, mana, inimigos restantes, armas e mensagens de `Game Over` diretamente sobre o canvas escalonado.【F:src/com/traduvertgames/main/Game.java†L229-L288】
 - **Áudio** – `Sound.java` encapsula efeitos de som e música ambiente utilizados ao interagir com o menu ou sofrer dano.【F:src/com/traduvertgames/main/Sound.java†L1-L120】
-- **Mundo** – A classe `World` carrega os tiles dos arquivos `level*.png`, gerando colisões, entidades e caminhos de A* a partir dos dados de pixels.【F:src/com/traduvertgames/world/World.java†L35-L210】
+- **Mundo** – A classe `World` carrega os tiles dos arquivos `level*.png`, gerando colisões, entidades e caminhos de A* a partir dos dados de pixels.【F:src/com/traduvertgames/world/World.java†L20-L145】
 
 ## Requisitos
 

--- a/docs/rotas-funcionalidades.md
+++ b/docs/rotas-funcionalidades.md
@@ -15,13 +15,13 @@ Este documento detalha o fluxo das principais rotas de execução do jogo, descr
 
 ## 3. Progressão de níveis
 
-- A cada atualização, quando `Game.enemies` fica vazio, `World.restartGame` é chamado para carregar o próximo mapa (`levelN.png`). Após concluir os quatro níveis padrão, `levelPlus` aumenta e atributos máximos do jogador são elevados para rodadas sucessivas.【F:src/com/traduvertgames/main/Game.java†L115-L154】
-- O arquivo do mundo define a distribuição de tiles, inimigos e itens; `World.java` traduz pixels do PNG em instâncias de `Tile`, `Enemy`, `LifePack`, `Weapon` e projéteis iniciais.【F:src/com/traduvertgames/world/World.java†L35-L210】
+- A cada atualização, quando `Game.enemies` fica vazio, `World.restartGame` é chamado para carregar o próximo mapa (`levelN.png`). Após concluir os quatro níveis padrão, `levelPlus` aumenta e atributos máximos do jogador são elevados para rodadas sucessivas.【F:src/com/traduvertgames/main/Game.java†L160-L187】
+- O arquivo do mundo define a distribuição de tiles, inimigos e itens; `World.java` traduz pixels do PNG em instâncias de `Tile`, `Enemy`, `LifePack`, `Weapon` e projéteis iniciais.【F:src/com/traduvertgames/world/World.java†L20-L145】
 
 ## 4. Sistema de entidades e combate
 
 - `Player` cuida da movimentação com checagem de colisão (`World.isFree`), salto simulado, recolhimento de itens e gerenciamento de vida/mana/munição. O disparo pode ser acionado por teclado ou mouse, gerando instâncias de `BulletShoot` ou `Bullet` adicionadas às listas do jogo.【F:src/com/traduvertgames/entities/Player.java†L19-L224】
-- `Enemy` utiliza `AStar.findPath` para seguir o jogador, alternando entre perseguição e ataque corpo a corpo. Ao causar dano, sinaliza feedback visual (`damage`) e incrementa contadores globais para estatísticas de HUD.【F:src/com/traduvertgames/entities/Enemy.java†L13-L164】
+- `Enemy` alterna entre patrulhas locais, perseguição com recálculo dinâmico de caminhos e ataques à distância quando há linha de visão, além de ainda poder causar dano corpo a corpo e sinalizar feedback visual (`damage`).【F:src/com/traduvertgames/entities/Enemy.java†L28-L369】
 - Ambas as subclasses de projéteis atualizam posicionamento, detectam colisões com paredes e inimigos e removem-se do jogo quando saem da área válida.【F:src/com/traduvertgames/entities/Bullet.java†L5-L12】【F:src/com/traduvertgames/entities/BulletShoot.java†L10-L41】
 
 ## 5. Salvamento e carregamento
@@ -37,5 +37,5 @@ Este documento detalha o fluxo das principais rotas de execução do jogo, descr
 ## 7. Recursos e assets
 
 - Sprites e sons residem em `res/`, com `Spritesheet` responsável por cortar imagens para as animações do jogador, inimigos e itens.【F:src/com/traduvertgames/main/Game.java†L63-L114】【F:src/com/traduvertgames/graficos/Spritesheet.java†L7-L82】
-- Os mapas (`level1.png` a `level4.png`) definem a "rota" espacial de cada fase, orientando tanto a geração de tiles (`FloorTile`, `WallTile`) quanto os nós de navegação usados pela IA de A*.【F:src/com/traduvertgames/world/World.java†L35-L210】【F:src/com/traduvertgames/world/AStar.java†L9-L140】
+- Os mapas (`level1.png` a `level4.png`) definem a "rota" espacial de cada fase, orientando tanto a geração de tiles (`FloorTile`, `WallTile`) quanto os nós de navegação usados pela IA de A*.【F:src/com/traduvertgames/world/World.java†L20-L145】【F:src/com/traduvertgames/world/AStar.java†L9-L140】
 

--- a/src/com/traduvertgames/entities/BulletShoot.java
+++ b/src/com/traduvertgames/entities/BulletShoot.java
@@ -6,36 +6,59 @@ import java.awt.image.BufferedImage;
 
 import com.traduvertgames.main.Game;
 import com.traduvertgames.world.Camera;
+import com.traduvertgames.world.World;
 
 public class BulletShoot extends Entity {
 
-	private double dx;
-	private double dy;
-	private double spd = 4;
+        private double dx;
+        private double dy;
+        private double spd = 4;
 
-	private int life = 30, curLife = 0;
+        private int life = 30, curLife = 0;
 
-	public BulletShoot(int x, int y, int width, int height, BufferedImage sprite, double dx, double dy) {
-		super(x, y, width, height, sprite);
-		this.dx = dx;
-		this.dy = dy;
-	}
+        private final boolean fromEnemy;
 
-	public void update() {
-		x += dx * spd;
-		y += dy * spd;
-		curLife++;
-		//Remover a bala em 3 segundos dps de disparada
-		if (curLife == life) {
-			// Sempre damos um return quando removemos o próprio objeto
-			Game.bullets.remove(this);
-			return;
-		}
-	}
+        public BulletShoot(int x, int y, int width, int height, BufferedImage sprite, double dx, double dy,
+                        boolean fromEnemy) {
+                super(x, y, width, height, sprite);
+                this.dx = dx;
+                this.dy = dy;
+                this.fromEnemy = fromEnemy;
+        }
 
-	public void render(Graphics g) {
-		g.setColor(Color.pink);
-		g.fillOval(this.getX() - Camera.x, this.getY() - Camera.y, width, height);
-	}
+        public void update() {
+                x += dx * spd;
+                y += dy * spd;
+                curLife++;
+                // Remover caso atinja uma parede ou saia do mapa
+                if (hitWall() || curLife >= life) {
+                        Game.bullets.remove(this);
+                        return;
+                }
+
+                if (fromEnemy) {
+                        if (Entity.isColliding(this, Game.player)) {
+                                Game.player.life -= 2;
+                                Game.player.damage = true;
+                                Game.bullets.remove(this);
+                                return;
+                        }
+                }
+        }
+
+        public void render(Graphics g) {
+                g.setColor(Color.pink);
+                g.fillOval(this.getX() - Camera.x, this.getY() - Camera.y, width, height);
+        }
+
+        private boolean hitWall() {
+                int centerX = this.getX() + width / 2;
+                int centerY = this.getY() + height / 2;
+                return World.isWallByPixel(centerX, centerY);
+        }
+
+        public boolean isFromEnemy() {
+                return fromEnemy;
+        }
 
 }

--- a/src/com/traduvertgames/entities/Enemy.java
+++ b/src/com/traduvertgames/entities/Enemy.java
@@ -1,8 +1,6 @@
 package com.traduvertgames.entities;
 
-import java.awt.Color;
 import java.awt.Graphics;
-import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.util.List;
 
@@ -25,14 +23,40 @@ public class Enemy extends Entity {
 	private boolean isDamaged = false;
 	private int damageFrames = 10, damageCurrent = 0;
 //	private int maskx=8,masky=8,maskw=10,maskh=10;
-	public static boolean addEnemy;
+        public static boolean addEnemy;
 
-	public Enemy(int x, int y, int width, int height, BufferedImage sprite) {
-		super(x, y, width, height, null);
-		sprites = new BufferedImage[2];
-		sprites[0] = Game.spritesheet.getSprite(112, 16, 16, 16);
-		sprites[1] = Game.spritesheet.getSprite(112 + 16, 16, 16, 16);
-	}
+        private enum EnemyState {
+                PATROLLING,
+                CHASING
+        }
+
+        private EnemyState state = EnemyState.PATROLLING;
+        private Vector2i spawnTile;
+        private Vector2i patrolTarget;
+        private int patrolTimer = 0;
+        private int pathCooldown = 0;
+        private int attackCooldown = 0;
+        private int strafeDirection = 1;
+        private int strafeTimer = 0;
+
+        private static final double PATROL_SPEED = 0.6;
+        private static final double CHASE_SPEED = 1.2;
+        private static final double STRAFE_SPEED = 0.9;
+        private static final double DETECTION_RADIUS = 160.0;
+        private static final double LOSE_INTEREST_RADIUS = 220.0;
+        private static final double ATTACK_RANGE = 120.0;
+        private static final double STRAFE_RANGE = 42.0;
+        private static final int PATROL_INTERVAL = 120;
+        private static final int PATH_RECALC_INTERVAL = 18;
+        private static final int MAX_ATTACK_COOLDOWN = 75;
+
+        public Enemy(int x, int y, int width, int height, BufferedImage sprite) {
+                super(x, y, width, height, null);
+                sprites = new BufferedImage[2];
+                sprites[0] = Game.spritesheet.getSprite(112, 16, 16, 16);
+                sprites[1] = Game.spritesheet.getSprite(112 + 16, 16, 16, 16);
+                spawnTile = new Vector2i(x / 16, y / 16);
+        }
 
         public void update() {
 
@@ -43,36 +67,38 @@ public class Enemy extends Entity {
                 mwidth = 8;
                 mheight = 8;
 
+                if (attackCooldown > 0) {
+                        attackCooldown--;
+                }
+                if (pathCooldown > 0) {
+                        pathCooldown--;
+                }
+                if (strafeTimer > 0) {
+                        strafeTimer--;
+                }
+
                 double distanceToPlayer = this.calculateDistance(this.getX(), this.getY(), Game.player.getX(),
                                 Game.player.getY());
+                boolean canSeePlayer = hasLineOfSightToPlayer();
 
-                if (distanceToPlayer < 120) {
-                        if (!isCollidingWithPlayer()) {
-                                if (path == null || path.isEmpty() || Game.rand.nextInt(100) < 5) {
-                                        Vector2i startNode = new Vector2i((int) (x / 16), (int) (y / 16));
-                                        Vector2i endNode = new Vector2i((int) (Game.player.x / 16), (int) (Game.player.y / 16));
-                                        path = AStar.findPath(Game.world, startNode, endNode);
-                                }
-
-                                if (path != null && !path.isEmpty()) {
-                                        followPath(path);
-                                }
-                        } else {
-                                if (Game.rand.nextInt(100) < 10) {
-                                        Game.player.life -= Game.rand.nextInt(3);
-                                        Game.player.damage = true;
-                                }
+                if (state == EnemyState.PATROLLING) {
+                        handlePatrol();
+                        if (distanceToPlayer <= DETECTION_RADIUS
+                                        && (canSeePlayer || distanceToPlayer <= DETECTION_RADIUS / 2)) {
+                                state = EnemyState.CHASING;
+                                path = null;
+                        }
+                } else {
+                        handleChase(distanceToPlayer, canSeePlayer);
+                        if (distanceToPlayer > LOSE_INTEREST_RADIUS && !canSeePlayer) {
+                                state = EnemyState.PATROLLING;
+                                patrolTarget = null;
+                                path = null;
+                                patrolTimer = 0;
                         }
                 }
 
-                frames++;
-                if (frames == maxFrames) {
-                        frames = 0;
-                        index++;
-                        if (index > maxIndex) {
-                                index = 0;
-                        }
-                }
+                animate();
 
                 collidingBullet();
                 if (life <= 0) {
@@ -101,24 +127,249 @@ public class Enemy extends Entity {
                 }
 
         }
+
+        private void animate() {
+                frames++;
+                if (frames >= maxFrames) {
+                        frames = 0;
+                        index++;
+                        if (index > maxIndex) {
+                                index = 0;
+                        }
+                }
+        }
+
+        private void handlePatrol() {
+                if (patrolTimer > 0) {
+                        patrolTimer--;
+                }
+
+                if ((patrolTarget == null || reachedTile(patrolTarget) || path == null || path.isEmpty())
+                                && patrolTimer <= 0) {
+                        chooseNewPatrolTarget();
+                }
+
+                if (path != null && !path.isEmpty()) {
+                        moveAlongPath(PATROL_SPEED);
+                }
+        }
+
+        private void handleChase(double distanceToPlayer, boolean canSeePlayer) {
+                if (distanceToPlayer > STRAFE_RANGE) {
+                        if (canSeePlayer) {
+                                moveDirectlyTowardsPlayer(CHASE_SPEED);
+                        } else {
+                                recalculatePathToPlayer();
+                                if (path != null && !path.isEmpty()) {
+                                        moveAlongPath(CHASE_SPEED);
+                                }
+                        }
+                } else {
+                        strafeAroundPlayer();
+                }
+
+                if (canSeePlayer) {
+                        if (distanceToPlayer <= ATTACK_RANGE) {
+                                shootAtPlayer();
+                        }
+                } else {
+                        recalculatePathToPlayer();
+                }
+
+                if (isCollidingWithPlayer()) {
+                        if (Game.rand.nextInt(100) < 20) {
+                                Game.player.life -= 2;
+                                Game.player.damage = true;
+                        }
+                }
+        }
+
+        private void moveAlongPath(double speed) {
+                if (path == null || path.isEmpty()) {
+                        return;
+                }
+
+                Vector2i target = path.get(path.size() - 1).tile;
+                double targetX = target.x * 16;
+                double targetY = target.y * 16;
+                double dx = targetX - x;
+                double dy = targetY - y;
+                double distance = Math.sqrt(dx * dx + dy * dy);
+
+                if (distance < 1) {
+                        x = targetX;
+                        y = targetY;
+                        path.remove(path.size() - 1);
+                        return;
+                }
+
+                double stepX = (dx / distance) * speed;
+                double stepY = (dy / distance) * speed;
+                if (!tryMove(stepX, stepY)) {
+                        path.remove(path.size() - 1);
+                }
+        }
+
+        private void moveDirectlyTowardsPlayer(double speed) {
+                double angle = Math.atan2(Game.player.getY() - this.getY(), Game.player.getX() - this.getX());
+                double stepX = Math.cos(angle) * speed;
+                double stepY = Math.sin(angle) * speed;
+                if (!tryMove(stepX, stepY)) {
+                        recalculatePathToPlayer();
+                }
+        }
+
+        private void strafeAroundPlayer() {
+                if (strafeTimer <= 0) {
+                        strafeDirection = Game.rand.nextBoolean() ? 1 : -1;
+                        strafeTimer = 30;
+                }
+
+                double angle = Math.atan2(Game.player.getY() - this.getY(), Game.player.getX() - this.getX());
+                double perpendicular = angle + (Math.PI / 2) * strafeDirection;
+                double stepX = Math.cos(perpendicular) * STRAFE_SPEED;
+                double stepY = Math.sin(perpendicular) * STRAFE_SPEED;
+
+                if (!tryMove(stepX, stepY)) {
+                        strafeDirection *= -1;
+                        tryMove(Math.cos(angle) * CHASE_SPEED * 0.5, Math.sin(angle) * CHASE_SPEED * 0.5);
+                        strafeTimer = 15;
+                }
+        }
+
+        private boolean tryMove(double dx, double dy) {
+                boolean moved = false;
+                double newX = x + dx;
+                double newY = y + dy;
+
+                if (World.isFree((int) newX, (int) y, 0)) {
+                        x = newX;
+                        moved = true;
+                }
+
+                if (World.isFree((int) x, (int) newY, 0)) {
+                        y = newY;
+                        moved = true;
+                }
+
+                return moved;
+        }
+
+        private boolean hasLineOfSightToPlayer() {
+                int startX = this.getX() + this.mwidth / 2;
+                int startY = this.getY() + this.mheight / 2;
+                int endX = Game.player.getX() + Game.player.getWidth() / 2;
+                int endY = Game.player.getY() + Game.player.getHeight() / 2;
+
+                int steps = Math.max(Math.abs(endX - startX), Math.abs(endY - startY));
+                if (steps == 0) {
+                        return true;
+                }
+
+                double stepX = (endX - startX) / (double) steps;
+                double stepY = (endY - startY) / (double) steps;
+                double currentX = startX;
+                double currentY = startY;
+
+                for (int i = 0; i < steps; i++) {
+                        currentX += stepX;
+                        currentY += stepY;
+                        int tileX = (int) (currentX / World.TILE_SIZE);
+                        int tileY = (int) (currentY / World.TILE_SIZE);
+                        if (World.isWallTile(tileX, tileY)) {
+                                return false;
+                        }
+                }
+
+                return true;
+        }
+
+        private void recalculatePathToPlayer() {
+                if (pathCooldown > 0) {
+                        return;
+                }
+
+                Vector2i startNode = new Vector2i((int) (x / 16), (int) (y / 16));
+                Vector2i endNode = new Vector2i(Game.player.getX() / 16, Game.player.getY() / 16);
+                List<Node> newPath = AStar.findPath(Game.world, startNode, endNode);
+                if (newPath != null && !newPath.isEmpty()) {
+                        path = newPath;
+                }
+
+                pathCooldown = PATH_RECALC_INTERVAL;
+        }
+
+        private void chooseNewPatrolTarget() {
+                int attempts = 0;
+                while (attempts < 8) {
+                        attempts++;
+                        int radius = 4;
+                        int tileX = spawnTile.x + Game.rand.nextInt(radius * 2 + 1) - radius;
+                        int tileY = spawnTile.y + Game.rand.nextInt(radius * 2 + 1) - radius;
+
+                        if (!World.isValidTile(tileX, tileY) || World.isWallTile(tileX, tileY)) {
+                                continue;
+                        }
+
+                        Vector2i startNode = new Vector2i((int) (x / 16), (int) (y / 16));
+                        Vector2i candidate = new Vector2i(tileX, tileY);
+                        List<Node> newPath = AStar.findPath(Game.world, startNode, candidate);
+                        if (newPath != null && !newPath.isEmpty()) {
+                                path = newPath;
+                                patrolTarget = candidate;
+                                patrolTimer = PATROL_INTERVAL;
+                                return;
+                        }
+                }
+
+                patrolTimer = PATROL_INTERVAL / 2;
+        }
+
+        private boolean reachedTile(Vector2i tile) {
+                if (tile == null) {
+                        return false;
+                }
+                return this.getX() / 16 == tile.x && this.getY() / 16 == tile.y;
+        }
+
+        private void shootAtPlayer() {
+                if (attackCooldown > 0) {
+                        return;
+                }
+
+                double angle = Math.atan2(Game.player.getY() - this.getY(), Game.player.getX() - this.getX());
+                double dx = Math.cos(angle);
+                double dy = Math.sin(angle);
+                BulletShoot bullet = new BulletShoot(this.getX() + 8, this.getY() + 8, 4, 4, null, dx, dy, true);
+                bullet.setMask(0, 0, 4, 4);
+                Game.bullets.add(bullet);
+                attackCooldown = MAX_ATTACK_COOLDOWN - Game.rand.nextInt(20);
+        }
 	public void destroySelf() {
 		Game.enemies.remove(this);
 		Game.entities.remove(this);
 	}
 
 	// Tirando dano com tiro
-	public void collidingBullet() {
-		for (int i = 0; i < Game.bullets.size(); i++) {
-			Entity e = Game.bullets.get(i);
-			if (Entity.isColliding(this, e)) {
-				isDamaged = true;
-				life--;
-				Game.bullets.remove(i);
-				return;
-			}
-		}
+        public void collidingBullet() {
+                for (int i = 0; i < Game.bullets.size(); i++) {
+                        Entity e = Game.bullets.get(i);
+                        if (e instanceof BulletShoot) {
+                                BulletShoot bullet = (BulletShoot) e;
+                                if (bullet.isFromEnemy()) {
+                                        continue;
+                                }
+                        }
 
-	}
+                        if (Entity.isColliding(this, e)) {
+                                isDamaged = true;
+                                life--;
+                                Game.bullets.remove(i);
+                                return;
+                        }
+                }
+
+        }
 
 	// Fazer nenhum NPC colidir com o outro
 //			public boolean isColliding(int xNext, int yNext) {

--- a/src/com/traduvertgames/entities/Player.java
+++ b/src/com/traduvertgames/entities/Player.java
@@ -207,7 +207,8 @@ public class Player extends Entity {
 					da = -3;
 				}
 
-				BulletShoot bullet = new BulletShoot(this.getX() + pd, this.getY() + pz, 3, 3, null, da, 0);
+                                BulletShoot bullet = new BulletShoot(this.getX() + pd, this.getY() + pz, 3, 3, null, da, 0,
+                                                false);
 				Game.bullets.add(bullet);
 			}
 		}
@@ -238,7 +239,8 @@ public class Player extends Entity {
 				double dx = Math.cos(angle);
 				double dy = Math.sin(angle);
 
-				BulletShoot bullet = new BulletShoot(this.getX() + px, this.getY() + py, 3, 3, null, dx, dy);
+                                BulletShoot bullet = new BulletShoot(this.getX() + px, this.getY() + py, 3, 3, null, dx, dy,
+                                                false);
 				Game.bullets.add(bullet);
 			}
 

--- a/src/com/traduvertgames/main/Game.java
+++ b/src/com/traduvertgames/main/Game.java
@@ -42,7 +42,7 @@ public class Game extends Canvas implements Runnable, KeyListener, MouseListener
 	public static final int HEIGHT = 160;
 	public static final int SCALE = 3;
 
-	private int CUR_LEVEL = 1, MAX_LEVEL = 4;
+        private int CUR_LEVEL = 1, MAX_LEVEL = 4;
 	private BufferedImage image;
 
 	public static List<Entity> entities;

--- a/src/com/traduvertgames/world/World.java
+++ b/src/com/traduvertgames/world/World.java
@@ -96,24 +96,41 @@ public class World {
 		return false;
 	}
 	
-	public static void restartGame(String level) {
-		Game.entities.clear();
-		Game.enemies.clear();
-		Game.entities = new ArrayList<Entity>();
-		Game.enemies = new ArrayList<Enemy>();
-		Game.spritesheet = new Spritesheet("/spritesheet.png");
-		// Passando tamanho dele e posições
-		Game.player = new Player(0, 0, 16, 16, Game.spritesheet.getSprite(32, 0, 16, 16));
-		// Adicionar o jogador na lista e ja aparece na tela
-		Game.entities.add(Game.player);
-		Game.world = new World("/"+level);
-		return;
-	}
-	public void render(Graphics g) {
-		
-		//Otimizando e renderizando o mapa apenas para onde a Câmera pega
-		int xstart = Camera.x / 16;
-		int ystart = Camera.y / 16;
+        public static void restartGame(String level) {
+                Game.entities.clear();
+                Game.enemies.clear();
+                Game.entities = new ArrayList<Entity>();
+                Game.enemies = new ArrayList<Enemy>();
+                Game.spritesheet = new Spritesheet("/spritesheet.png");
+                // Passando tamanho dele e posições
+                Game.player = new Player(0, 0, 16, 16, Game.spritesheet.getSprite(32, 0, 16, 16));
+                // Adicionar o jogador na lista e ja aparece na tela
+                Game.entities.add(Game.player);
+                Game.world = new World("/"+level);
+                return;
+        }
+
+        public static boolean isValidTile(int tileX, int tileY) {
+                return tileX >= 0 && tileY >= 0 && tileX < WIDTH && tileY < HEIGHT;
+        }
+
+        public static boolean isWallTile(int tileX, int tileY) {
+                if (!isValidTile(tileX, tileY)) {
+                        return true;
+                }
+                return tiles[tileX + (tileY * WIDTH)] instanceof WallTile;
+        }
+
+        public static boolean isWallByPixel(int pixelX, int pixelY) {
+                int tileX = pixelX / TILE_SIZE;
+                int tileY = pixelY / TILE_SIZE;
+                return isWallTile(tileX, tileY);
+        }
+        public void render(Graphics g) {
+
+                //Otimizando e renderizando o mapa apenas para onde a Câmera pega
+                int xstart = Camera.x / 16;
+                int ystart = Camera.y / 16;
 
 		int xfinal = xstart + (Game.WIDTH / 16) ;
 		int yfinal = ystart + (Game.HEIGHT / 16) ;


### PR DESCRIPTION
## Summary
- rework enemy behaviour to include patrols, smarter path recalculation, strafing and ranged attacks using shared projectile logic
- extend world and projectile utilities to support line-of-sight checks, projectile collision with walls, and enemy-safe bullet handling
- update the campaign assets to four stages, removing the level5/level6 binaries and aligning documentation with the available maps

## Testing
- `./gradlew build` *(fails: Gradle wrapper download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68f3d470b6288331b9a0182a1678dc17