### PR TITLE
Fix restart flow and extend save persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Os recursos, como sprites e áudio, estão localizados no diretório `res/`, enq
 
 ## Sistema de salvamento
 
-O jogo grava dados como vida, mana, inimigos derrotados e fase atual em `save.txt`, aplicando uma codificação simples. A opção "carregar jogo" do menu lê esse arquivo e restaura o progresso, inclusive o mapa corrente.【F:src/com/traduvertgames/main/Game.java†L87-L154】【F:src/com/traduvertgames/main/Menu.java†L58-L158】
+O jogo grava vida, mana, quantidade de munição (arma), inimigos derrotados, progresso de `levelPlus` e fase atual em `save.txt`, aplicando uma codificação simples. A opção "carregar jogo" do menu lê esse arquivo, restaura atributos do jogador e recarrega o mapa correspondente. Ao morrer, pressionar `Enter` recarrega automaticamente o último save disponível; caso o arquivo não exista, um novo jogo é iniciado do nível 1 com todos os recursos resetados.【F:src/com/traduvertgames/main/Game.java†L63-L156】【F:src/com/traduvertgames/main/Game.java†L409-L637】【F:src/com/traduvertgames/main/Menu.java†L24-L162】
 
 ## HUD, áudio e recursos
 

--- a/src/com/traduvertgames/world/World.java
+++ b/src/com/traduvertgames/world/World.java
@@ -101,6 +101,8 @@ public class World {
                 Game.enemies.clear();
                 Game.entities = new ArrayList<Entity>();
                 Game.enemies = new ArrayList<Enemy>();
+                Game.bullet = new ArrayList<Bullet>();
+                Game.bullets = new ArrayList<BulletShoot>();
                 Game.spritesheet = new Spritesheet("/spritesheet.png");
                 // Passando tamanho dele e posições
                 Game.player = new Player(0, 0, 16, 16, Game.spritesheet.getSprite(32, 0, 16, 16));


### PR DESCRIPTION
## Summary
- ensure the game exposes a singleton instance and new helpers to reset progress, reload saves, and keep player stats valid when restarting after death
- update the menu to start fresh runs properly, parse additional save fields, and rely on the new restart utilities
- recreate projectile lists when reloading worlds and document the improved save/restart behaviour

## Testing
- ./gradlew build *(fails: Gradle wrapper cannot be downloaded in the CI proxy environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3daad106483319f1a40dd9fea6424