### PR TITLE
Expand viewport and add elite enemy variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Os recursos, como sprites e áudio, estão localizados no diretório `res/`, enq
 - **Vida, mana e munição** – O jogador possui barras máximas configuradas dinamicamente; pacotes de vida (`LifePack`) e armas (`Weapon`) são coletados via colisão para restaurar recursos.【F:src/com/traduvertgames/entities/Player.java†L19-L118】【F:src/com/traduvertgames/entities/Entity.java†L109-L194】
 - **Arsenal modular** – Quatro armas com características próprias (Blaster, Rifle de Íons, Canhão Dispersor e Lança de Fusão) podem ser desbloqueadas, cada uma com custos de mana, dano e cadência diferenciados. A durabilidade de cada arma é persistida no save e pode ser reabastecida ao coletar novos itens.【F:src/com/traduvertgames/entities/WeaponType.java†L16-L161】【F:src/com/traduvertgames/entities/Player.java†L323-L512】【F:src/com/traduvertgames/main/Menu.java†L120-L185】
 - **Projéteis** – Há dois tipos de disparo (`Bullet` e `BulletShoot`) com atualizações e renderização independentes; os disparos energizados (`BulletShoot`) agora também são utilizados pelos inimigos para ataques à distância.【F:src/com/traduvertgames/entities/Bullet.java†L5-L12】【F:src/com/traduvertgames/entities/BulletShoot.java†L12-L52】
-- **Inimigos** – A IA intercala patrulha, perseguição com recálculo dinâmico de caminhos, flanqueia o jogador e dispara projéteis sempre que há linha de visão, contabilizando eliminações para avançar de fase.【F:src/com/traduvertgames/entities/Enemy.java†L28-L370】
+- **Inimigos** – A IA intercala patrulha, perseguição com recálculo dinâmico de caminhos, flanqueia o jogador e dispara projéteis sempre que há linha de visão. Além do tipo padrão, o carregamento de fases passa a sortear variantes teletransportadoras e artilheiros, cada uma com padrões de disparo próprios; também é possível posicioná-las explicitamente nos mapas usando os códigos de cor `#9C27B0` e `#00BCD4`.【F:src/com/traduvertgames/entities/Enemy.java†L17-L367】【F:src/com/traduvertgames/world/World.java†L33-L88】
 
 ## Pontuação e combos
 
@@ -48,7 +48,7 @@ O jogo grava vida, mana, quantidade de munição (arma), inimigos derrotados, pr
 
 ## HUD, áudio e recursos
 
-- **HUD** – A classe `UI` exibe barras compactas dentro do canvas e, após o escalonamento, projeta painéis translúcidos com status do piloto, placar da missão e arsenal desbloqueado, reduzindo a poluição visual do HUD antigo.【F:src/com/traduvertgames/main/Game.java†L348-L399】【F:src/com/traduvertgames/graficos/UI.java†L17-L157】
+- **HUD** – A classe `UI` exibe barras compactas dentro do canvas e, após o escalonamento, projeta painéis translúcidos com status do piloto, placar da missão e arsenal desbloqueado. O canvas agora opera em 320×192 pixels (960×576 após o `SCALE`), afastando os painéis laterais e centralizando a tela de game over para facilitar a leitura.【F:src/com/traduvertgames/main/Game.java†L37-L320】【F:src/com/traduvertgames/graficos/UI.java†L15-L124】
 - **Áudio** – `Sound.java` encapsula efeitos de som e música ambiente utilizados ao interagir com o menu ou sofrer dano.【F:src/com/traduvertgames/main/Sound.java†L1-L120】
 - **Mundo** – A classe `World` carrega os tiles dos arquivos `level*.png`, gerando colisões, entidades e caminhos de A* a partir dos dados de pixels.【F:src/com/traduvertgames/world/World.java†L20-L145】
 

--- a/src/com/traduvertgames/entities/BulletShoot.java
+++ b/src/com/traduvertgames/entities/BulletShoot.java
@@ -10,62 +10,73 @@ import com.traduvertgames.world.World;
 
 public class BulletShoot extends Entity {
 
-        private final double dx;
-        private final double dy;
-        private final double speed;
+    private final double dx;
+    private final double dy;
+    private final double speed;
+    private final Color overrideColor;
 
-        private int life = 30, curLife = 0;
+    private int life = 30, curLife = 0;
 
-        private final boolean fromEnemy;
-        private final double damage;
+    private final boolean fromEnemy;
+    private final double damage;
 
-        public BulletShoot(int x, int y, int width, int height, BufferedImage sprite, double dx, double dy,
-                        double speed, double damage, boolean fromEnemy) {
-                super(x, y, width, height, sprite);
-                this.dx = dx;
-                this.dy = dy;
-                this.speed = speed;
-                this.damage = damage;
-                this.fromEnemy = fromEnemy;
+    public BulletShoot(int x, int y, int width, int height, BufferedImage sprite, double dx, double dy,
+            double speed, double damage, boolean fromEnemy) {
+        this(x, y, width, height, sprite, dx, dy, speed, damage, fromEnemy, null);
+    }
+
+    public BulletShoot(int x, int y, int width, int height, BufferedImage sprite, double dx, double dy,
+            double speed, double damage, boolean fromEnemy, Color overrideColor) {
+        super(x, y, width, height, sprite);
+        this.dx = dx;
+        this.dy = dy;
+        this.speed = speed;
+        this.damage = damage;
+        this.fromEnemy = fromEnemy;
+        this.overrideColor = overrideColor;
+    }
+
+    public void update() {
+        x += dx * speed;
+        y += dy * speed;
+        curLife++;
+        // Remover caso atinja uma parede ou saia do mapa
+        if (hitWall() || curLife >= life) {
+            Game.bullets.remove(this);
+            return;
         }
 
-        public void update() {
-                x += dx * speed;
-                y += dy * speed;
-                curLife++;
-                // Remover caso atinja uma parede ou saia do mapa
-                if (hitWall() || curLife >= life) {
-                        Game.bullets.remove(this);
-                        return;
-                }
-
-                if (fromEnemy) {
-                        if (Entity.isColliding(this, Game.player)) {
-                                Game.player.life -= damage;
-                                Game.player.damage = true;
-                                Game.registerPlayerDamage();
-                                Game.bullets.remove(this);
-                                return;
-                        }
-                }
+        if (fromEnemy) {
+            if (Entity.isColliding(this, Game.player)) {
+                Game.player.life -= damage;
+                Game.player.damage = true;
+                Game.registerPlayerDamage();
+                Game.bullets.remove(this);
+                return;
+            }
         }
+    }
 
-        public void render(Graphics g) {
-                g.setColor(fromEnemy ? Color.ORANGE : Color.pink);
-                g.fillOval(this.getX() - Camera.x, this.getY() - Camera.y, width, height);
+    public void render(Graphics g) {
+        Color color = overrideColor;
+        if (color == null) {
+            color = fromEnemy ? Color.ORANGE : Color.pink;
         }
+        g.setColor(color);
+        g.fillOval(this.getX() - Camera.x, this.getY() - Camera.y, width, height);
+    }
 
-        private boolean hitWall() {
-                int centerX = this.getX() + width / 2;
-                int centerY = this.getY() + height / 2;
-                return World.isWallByPixel(centerX, centerY);
-        }
+    private boolean hitWall() {
+        int centerX = this.getX() + width / 2;
+        int centerY = this.getY() + height / 2;
+        return World.isWallByPixel(centerX, centerY);
+    }
 
-        public boolean isFromEnemy() {
-                return fromEnemy;
-        }
+    public boolean isFromEnemy() {
+        return fromEnemy;
+    }
 
-        public double getDamage() {
-                return damage;
-        }
+    public double getDamage() {
+        return damage;
+    }
 }

--- a/src/com/traduvertgames/entities/Enemy.java
+++ b/src/com/traduvertgames/entities/Enemy.java
@@ -1,10 +1,10 @@
 package com.traduvertgames.entities;
 
+import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.util.List;
 
-import com.traduvertgames.entities.Entity;
 import com.traduvertgames.main.Game;
 import com.traduvertgames.world.AStar;
 import com.traduvertgames.world.Camera;
@@ -14,411 +14,621 @@ import com.traduvertgames.world.World;
 
 public class Enemy extends Entity {
 
-        private int frames = 0, maxFrames = 20, index = 0, maxIndex = 1;
-	private BufferedImage[] sprites;
-	public static int enemies = 0;
+    private int frames = 0, maxFrames = 20, index = 0, maxIndex = 1;
+    private BufferedImage[] sprites;
+    public static int enemies = 0;
 
-        private double life = 2;
+    private double life;
+    private final double maxLife;
 
-	private boolean isDamaged = false;
-	private int damageFrames = 10, damageCurrent = 0;
-//	private int maskx=8,masky=8,maskw=10,maskh=10;
-        public static boolean addEnemy;
+    private boolean isDamaged = false;
+    private int damageFrames = 10, damageCurrent = 0;
+    public static boolean addEnemy;
 
-        private enum EnemyState {
-                PATROLLING,
-                CHASING
+    private enum EnemyState {
+        PATROLLING,
+        CHASING
+    }
+
+    public enum Variant {
+        SCOUT(2.0, 1.0, 1.0, 4.0, 2.0, 4, 75, 0, 0, new Color(255, 152, 0)),
+        TELEPORTER(3.5, 1.1, 1.25, 5.5, 1.6, 4, 60, 220, 96, new Color(156, 39, 176)),
+        ARTILLERY(6.0, 0.85, 0.9, 3.6, 2.8, 5, 110, 260, 128, new Color(3, 169, 244));
+
+        private final double maxLife;
+        private final double speedMultiplier;
+        private final double strafeMultiplier;
+        private final double projectileSpeed;
+        private final double projectileDamage;
+        private final int projectileSize;
+        private final int attackCooldown;
+        private final int specialCooldown;
+        private final double specialRange;
+        private final Color color;
+
+        Variant(double maxLife, double speedMultiplier, double strafeMultiplier, double projectileSpeed,
+                double projectileDamage, int projectileSize, int attackCooldown, int specialCooldown, double specialRange,
+                Color color) {
+            this.maxLife = maxLife;
+            this.speedMultiplier = speedMultiplier;
+            this.strafeMultiplier = strafeMultiplier;
+            this.projectileSpeed = projectileSpeed;
+            this.projectileDamage = projectileDamage;
+            this.projectileSize = projectileSize;
+            this.attackCooldown = attackCooldown;
+            this.specialCooldown = specialCooldown;
+            this.specialRange = specialRange;
+            this.color = color;
         }
 
-        private EnemyState state = EnemyState.PATROLLING;
-        private Vector2i spawnTile;
-        private Vector2i patrolTarget;
-        private int patrolTimer = 0;
-        private int pathCooldown = 0;
-        private int attackCooldown = 0;
-        private int strafeDirection = 1;
-        private int strafeTimer = 0;
-
-        private static final double PATROL_SPEED = 0.6;
-        private static final double CHASE_SPEED = 1.2;
-        private static final double STRAFE_SPEED = 0.9;
-        private static final double DETECTION_RADIUS = 160.0;
-        private static final double LOSE_INTEREST_RADIUS = 220.0;
-        private static final double ATTACK_RANGE = 120.0;
-        private static final double STRAFE_RANGE = 42.0;
-        private static final int PATROL_INTERVAL = 120;
-        private static final int PATH_RECALC_INTERVAL = 18;
-        private static final int MAX_ATTACK_COOLDOWN = 75;
-
-        public Enemy(int x, int y, int width, int height, BufferedImage sprite) {
-                super(x, y, width, height, null);
-                sprites = new BufferedImage[2];
-                sprites[0] = Game.spritesheet.getSprite(112, 16, 16, 16);
-                sprites[1] = Game.spritesheet.getSprite(112 + 16, 16, 16, 16);
-                spawnTile = new Vector2i(x / 16, y / 16);
+        double getMaxLife() {
+            return maxLife;
         }
 
-        public void update() {
-
-                depth = 0;
-                // Ajustando a mascara de colisao.
-                maskx = 8;
-                masky = 8;
-                mwidth = 8;
-                mheight = 8;
-
-                if (attackCooldown > 0) {
-                        attackCooldown--;
-                }
-                if (pathCooldown > 0) {
-                        pathCooldown--;
-                }
-                if (strafeTimer > 0) {
-                        strafeTimer--;
-                }
-
-                double distanceToPlayer = this.calculateDistance(this.getX(), this.getY(), Game.player.getX(),
-                                Game.player.getY());
-                boolean canSeePlayer = hasLineOfSightToPlayer();
-
-                if (state == EnemyState.PATROLLING) {
-                        handlePatrol();
-                        if (distanceToPlayer <= DETECTION_RADIUS
-                                        && (canSeePlayer || distanceToPlayer <= DETECTION_RADIUS / 2)) {
-                                state = EnemyState.CHASING;
-                                path = null;
-                        }
-                } else {
-                        handleChase(distanceToPlayer, canSeePlayer);
-                        if (distanceToPlayer > LOSE_INTEREST_RADIUS && !canSeePlayer) {
-                                state = EnemyState.PATROLLING;
-                                patrolTarget = null;
-                                path = null;
-                                patrolTimer = 0;
-                        }
-                }
-
-                animate();
-
-                collidingBullet();
-                if (life <= 0) {
-                        destroySelf();
-                        enemies += 1;
-
-                        if (Game.enemies.size() == 0) {
-                                addEnemy = true;
-                        }
-                        return;
-                }
-
-                if (Enemy.addEnemy) {
-                        Enemy en = new Enemy(1 * 16, 1 * 16, 16, 16, Entity.ENEMY_EN);
-                        Game.entities.add(en);
-                        Game.enemies.add(en);
-                        Enemy.addEnemy = false;
-                }
-
-                if (isDamaged) {
-                        this.damageCurrent++;
-                        if (this.damageCurrent == this.damageFrames) {
-                                this.damageCurrent = 0;
-                                this.isDamaged = false;
-                        }
-                }
-
+        double getSpeedMultiplier() {
+            return speedMultiplier;
         }
 
-        private void animate() {
-                frames++;
-                if (frames >= maxFrames) {
-                        frames = 0;
-                        index++;
-                        if (index > maxIndex) {
-                                index = 0;
-                        }
-                }
+        double getStrafeMultiplier() {
+            return strafeMultiplier;
         }
 
-        private void handlePatrol() {
-                if (patrolTimer > 0) {
-                        patrolTimer--;
-                }
+        double getProjectileSpeed() {
+            return projectileSpeed;
+        }
 
-                if ((patrolTarget == null || reachedTile(patrolTarget) || path == null || path.isEmpty())
-                                && patrolTimer <= 0) {
-                        chooseNewPatrolTarget();
-                }
+        double getProjectileDamage() {
+            return projectileDamage;
+        }
 
+        int getProjectileSize() {
+            return projectileSize;
+        }
+
+        int getAttackCooldown() {
+            return attackCooldown;
+        }
+
+        int getSpecialCooldown() {
+            return specialCooldown;
+        }
+
+        double getSpecialRange() {
+            return specialRange;
+        }
+
+        Color getProjectileColor() {
+            return color;
+        }
+
+        Color getAuraColor() {
+            return color;
+        }
+    }
+
+    private EnemyState state = EnemyState.PATROLLING;
+    private Vector2i spawnTile;
+    private Vector2i patrolTarget;
+    private int patrolTimer = 0;
+    private int pathCooldown = 0;
+    private int attackCooldown = 0;
+    private int strafeDirection = 1;
+    private int strafeTimer = 0;
+    private int specialCooldown = 0;
+
+    private final Variant variant;
+    private final double patrolSpeed;
+    private final double chaseSpeed;
+    private final double strafeSpeed;
+    private final double projectileSpeed;
+    private final double projectileDamage;
+    private final double specialRange;
+    private final int projectileSize;
+    private final int attackCooldownBase;
+    private final int specialCooldownBase;
+    private final Color projectileColor;
+    private final Color auraColor;
+
+    private static final double BASE_PATROL_SPEED = 0.6;
+    private static final double BASE_CHASE_SPEED = 1.2;
+    private static final double BASE_STRAFE_SPEED = 0.9;
+    private static final double DETECTION_RADIUS = 160.0;
+    private static final double LOSE_INTEREST_RADIUS = 220.0;
+    private static final double ATTACK_RANGE = 120.0;
+    private static final double STRAFE_RANGE = 42.0;
+    private static final int PATROL_INTERVAL = 120;
+    private static final int PATH_RECALC_INTERVAL = 18;
+
+    public Enemy(int x, int y, int width, int height, BufferedImage sprite) {
+        this(x, y, width, height, sprite, Variant.SCOUT);
+    }
+
+    public Enemy(int x, int y, int width, int height, BufferedImage sprite, Variant variant) {
+        super(x, y, width, height, null);
+        this.variant = variant;
+        this.maxLife = variant.getMaxLife();
+        this.life = this.maxLife;
+        sprites = new BufferedImage[2];
+        sprites[0] = Game.spritesheet.getSprite(112, 16, 16, 16);
+        sprites[1] = Game.spritesheet.getSprite(112 + 16, 16, 16, 16);
+        spawnTile = new Vector2i(x / 16, y / 16);
+        this.patrolSpeed = BASE_PATROL_SPEED * variant.getSpeedMultiplier();
+        this.chaseSpeed = BASE_CHASE_SPEED * variant.getSpeedMultiplier();
+        this.strafeSpeed = BASE_STRAFE_SPEED * variant.getStrafeMultiplier();
+        this.projectileSpeed = variant.getProjectileSpeed();
+        this.projectileDamage = variant.getProjectileDamage();
+        this.projectileSize = variant.getProjectileSize();
+        this.attackCooldownBase = Math.max(variant.getAttackCooldown(), 30);
+        this.specialCooldownBase = Math.max(0, variant.getSpecialCooldown());
+        this.specialRange = variant.getSpecialRange();
+        this.projectileColor = variant.getProjectileColor();
+        this.auraColor = variant.getAuraColor();
+        if (this.specialCooldownBase > 0) {
+            specialCooldown = Game.rand.nextInt(this.specialCooldownBase);
+        }
+    }
+
+    public static Enemy spawnRandomVariant(int x, int y) {
+        return new Enemy(x, y, 16, 16, Entity.ENEMY_EN, pickRandomVariant());
+    }
+
+    private static Variant pickRandomVariant() {
+        int roll = Game.rand.nextInt(100);
+        if (roll < 55) {
+            return Variant.SCOUT;
+        } else if (roll < 80) {
+            return Variant.TELEPORTER;
+        }
+        return Variant.ARTILLERY;
+    }
+
+    public void update() {
+
+        depth = 0;
+        maskx = 8;
+        masky = 8;
+        mwidth = 8;
+        mheight = 8;
+
+        if (attackCooldown > 0) {
+            attackCooldown--;
+        }
+        if (pathCooldown > 0) {
+            pathCooldown--;
+        }
+        if (strafeTimer > 0) {
+            strafeTimer--;
+        }
+
+        double distanceToPlayer = this.calculateDistance(this.getX(), this.getY(), Game.player.getX(),
+                Game.player.getY());
+        boolean canSeePlayer = hasLineOfSightToPlayer();
+
+        if (state == EnemyState.PATROLLING) {
+            handlePatrol();
+            if (distanceToPlayer <= DETECTION_RADIUS && (canSeePlayer || distanceToPlayer <= DETECTION_RADIUS / 2)) {
+                state = EnemyState.CHASING;
+                path = null;
+            }
+        } else {
+            handleChase(distanceToPlayer, canSeePlayer);
+            if (distanceToPlayer > LOSE_INTEREST_RADIUS && !canSeePlayer) {
+                state = EnemyState.PATROLLING;
+                patrolTarget = null;
+                path = null;
+                patrolTimer = 0;
+            }
+        }
+
+        updateVariantAbilities(distanceToPlayer, canSeePlayer);
+
+        animate();
+
+        collidingBullet();
+        if (life <= 0) {
+            destroySelf();
+            enemies += 1;
+
+            if (Game.enemies.size() == 0) {
+                addEnemy = true;
+            }
+            return;
+        }
+
+        if (Enemy.addEnemy) {
+            Enemy en = Enemy.spawnRandomVariant(1 * 16, 1 * 16);
+            Game.entities.add(en);
+            Game.enemies.add(en);
+            Enemy.addEnemy = false;
+        }
+
+        if (isDamaged) {
+            this.damageCurrent++;
+            if (this.damageCurrent == this.damageFrames) {
+                this.damageCurrent = 0;
+                this.isDamaged = false;
+            }
+        }
+
+    }
+
+    private void updateVariantAbilities(double distanceToPlayer, boolean canSeePlayer) {
+        if (variant == Variant.SCOUT) {
+            return;
+        }
+
+        if (specialCooldown > 0) {
+            specialCooldown--;
+        }
+
+        switch (variant) {
+        case TELEPORTER:
+            handleTeleportAbility(distanceToPlayer, canSeePlayer);
+            break;
+        case ARTILLERY:
+            handleArtilleryAbility(distanceToPlayer);
+            break;
+        default:
+            break;
+        }
+    }
+
+    private void handleTeleportAbility(double distanceToPlayer, boolean canSeePlayer) {
+        if (specialCooldown > 0) {
+            return;
+        }
+        boolean wantsTeleport = distanceToPlayer > Math.max(64, specialRange);
+        if (!canSeePlayer && distanceToPlayer > 48) {
+            wantsTeleport = true;
+        }
+        if (wantsTeleport && attemptTeleportNearPlayer()) {
+            specialCooldown = specialCooldownBase;
+            path = null;
+            state = EnemyState.CHASING;
+        }
+    }
+
+    private boolean attemptTeleportNearPlayer() {
+        int attempts = 10;
+        int minRadius = 48;
+        int maxRadius = 112;
+        for (int i = 0; i < attempts; i++) {
+            double angle = Game.rand.nextDouble() * Math.PI * 2;
+            double distance = minRadius + Game.rand.nextDouble() * (maxRadius - minRadius);
+            int targetX = Game.player.getX() + (int) Math.round(Math.cos(angle) * distance);
+            int targetY = Game.player.getY() + (int) Math.round(Math.sin(angle) * distance);
+            targetX = (targetX / 16) * 16;
+            targetY = (targetY / 16) * 16;
+
+            if (!World.isFree(targetX, targetY, 0)) {
+                continue;
+            }
+            if (this.calculateDistance(targetX, targetY, Game.player.getX(), Game.player.getY()) < 32) {
+                continue;
+            }
+            boolean collidingOther = false;
+            for (Enemy other : Game.enemies) {
+                if (other == this) {
+                    continue;
+                }
+                if (other.calculateDistance(targetX, targetY, other.getX(), other.getY()) < 16) {
+                    collidingOther = true;
+                    break;
+                }
+            }
+            if (collidingOther) {
+                continue;
+            }
+
+            this.x = targetX;
+            this.y = targetY;
+            strafeTimer = 0;
+            return true;
+        }
+        return false;
+    }
+
+    private void handleArtilleryAbility(double distanceToPlayer) {
+        if (specialCooldown > 0) {
+            return;
+        }
+        if (distanceToPlayer >= Math.max(96, specialRange - 16)) {
+            fireArtilleryBarrage();
+            specialCooldown = specialCooldownBase;
+        }
+    }
+
+    private void fireArtilleryBarrage() {
+        double angle = Math.atan2(Game.player.getY() - this.getY(), Game.player.getX() - this.getX());
+        double[] offsets = { -0.35, -0.18, 0.0, 0.18, 0.35 };
+        for (int i = 0; i < offsets.length; i++) {
+            double finalAngle = angle + offsets[i];
+            double speedModifier = i == 2 ? 1.1 : 0.85;
+            double damageModifier = i == 2 ? 1.2 : 0.8;
+            Color color = i == 2 ? projectileColor : projectileColor.brighter();
+            spawnProjectile(finalAngle, projectileSpeed * speedModifier, projectileDamage * damageModifier,
+                    projectileSize + (i == 2 ? 1 : 0), color);
+        }
+        attackCooldown = Math.max(attackCooldown, attackCooldownBase + 30);
+    }
+
+    private void animate() {
+        frames++;
+        if (frames >= maxFrames) {
+            frames = 0;
+            index++;
+            if (index > maxIndex) {
+                index = 0;
+            }
+        }
+    }
+
+    private void handlePatrol() {
+        if (patrolTimer > 0) {
+            patrolTimer--;
+        }
+
+        if ((patrolTarget == null || reachedTile(patrolTarget) || path == null || path.isEmpty()) && patrolTimer <= 0) {
+            chooseNewPatrolTarget();
+        }
+
+        if (path != null && !path.isEmpty()) {
+            moveAlongPath(patrolSpeed);
+        }
+    }
+
+    private void handleChase(double distanceToPlayer, boolean canSeePlayer) {
+        if (distanceToPlayer > STRAFE_RANGE) {
+            if (canSeePlayer) {
+                moveDirectlyTowardsPlayer(chaseSpeed);
+            } else {
+                recalculatePathToPlayer();
                 if (path != null && !path.isEmpty()) {
-                        moveAlongPath(PATROL_SPEED);
+                    moveAlongPath(chaseSpeed);
                 }
+            }
+        } else {
+            strafeAroundPlayer();
         }
 
-        private void handleChase(double distanceToPlayer, boolean canSeePlayer) {
-                if (distanceToPlayer > STRAFE_RANGE) {
-                        if (canSeePlayer) {
-                                moveDirectlyTowardsPlayer(CHASE_SPEED);
-                        } else {
-                                recalculatePathToPlayer();
-                                if (path != null && !path.isEmpty()) {
-                                        moveAlongPath(CHASE_SPEED);
-                                }
-                        }
-                } else {
-                        strafeAroundPlayer();
-                }
-
-                if (canSeePlayer) {
-                        if (distanceToPlayer <= ATTACK_RANGE) {
-                                shootAtPlayer();
-                        }
-                } else {
-                        recalculatePathToPlayer();
-                }
-
-                if (isCollidingWithPlayer()) {
-                        if (Game.rand.nextInt(100) < 20) {
-                                Game.player.life -= 2;
-                                Game.player.damage = true;
-                                Game.registerPlayerDamage();
-                        }
-                }
+        if (canSeePlayer) {
+            if (distanceToPlayer <= ATTACK_RANGE) {
+                shootAtPlayer();
+            }
+        } else {
+            recalculatePathToPlayer();
         }
 
-        private void moveAlongPath(double speed) {
-                if (path == null || path.isEmpty()) {
-                        return;
-                }
+        if (isCollidingWithPlayer()) {
+            if (Game.rand.nextInt(100) < 20) {
+                Game.player.life -= 2;
+                Game.player.damage = true;
+                Game.registerPlayerDamage();
+            }
+        }
+    }
 
-                Vector2i target = path.get(path.size() - 1).tile;
-                double targetX = target.x * 16;
-                double targetY = target.y * 16;
-                double dx = targetX - x;
-                double dy = targetY - y;
-                double distance = Math.sqrt(dx * dx + dy * dy);
-
-                if (distance < 1) {
-                        x = targetX;
-                        y = targetY;
-                        path.remove(path.size() - 1);
-                        return;
-                }
-
-                double stepX = (dx / distance) * speed;
-                double stepY = (dy / distance) * speed;
-                if (!tryMove(stepX, stepY)) {
-                        path.remove(path.size() - 1);
-                }
+    private void moveAlongPath(double speed) {
+        if (path == null || path.isEmpty()) {
+            return;
         }
 
-        private void moveDirectlyTowardsPlayer(double speed) {
-                double angle = Math.atan2(Game.player.getY() - this.getY(), Game.player.getX() - this.getX());
-                double stepX = Math.cos(angle) * speed;
-                double stepY = Math.sin(angle) * speed;
-                if (!tryMove(stepX, stepY)) {
-                        recalculatePathToPlayer();
-                }
+        Vector2i target = path.get(path.size() - 1).tile;
+        double targetX = target.x * 16;
+        double targetY = target.y * 16;
+        double dx = targetX - x;
+        double dy = targetY - y;
+        double distance = Math.sqrt(dx * dx + dy * dy);
+
+        if (distance < 1) {
+            x = targetX;
+            y = targetY;
+            path.remove(path.size() - 1);
+            return;
         }
 
-        private void strafeAroundPlayer() {
-                if (strafeTimer <= 0) {
-                        strafeDirection = Game.rand.nextBoolean() ? 1 : -1;
-                        strafeTimer = 30;
-                }
+        double stepX = (dx / distance) * speed;
+        double stepY = (dy / distance) * speed;
+        if (!tryMove(stepX, stepY)) {
+            path.remove(path.size() - 1);
+        }
+    }
 
-                double angle = Math.atan2(Game.player.getY() - this.getY(), Game.player.getX() - this.getX());
-                double perpendicular = angle + (Math.PI / 2) * strafeDirection;
-                double stepX = Math.cos(perpendicular) * STRAFE_SPEED;
-                double stepY = Math.sin(perpendicular) * STRAFE_SPEED;
+    private void moveDirectlyTowardsPlayer(double speed) {
+        double angle = Math.atan2(Game.player.getY() - this.getY(), Game.player.getX() - this.getX());
+        double stepX = Math.cos(angle) * speed;
+        double stepY = Math.sin(angle) * speed;
+        if (!tryMove(stepX, stepY)) {
+            recalculatePathToPlayer();
+        }
+    }
 
-                if (!tryMove(stepX, stepY)) {
-                        strafeDirection *= -1;
-                        tryMove(Math.cos(angle) * CHASE_SPEED * 0.5, Math.sin(angle) * CHASE_SPEED * 0.5);
-                        strafeTimer = 15;
-                }
+    private void strafeAroundPlayer() {
+        if (strafeTimer <= 0) {
+            strafeDirection = Game.rand.nextBoolean() ? 1 : -1;
+            strafeTimer = 30;
         }
 
-        private boolean tryMove(double dx, double dy) {
-                boolean moved = false;
-                double newX = x + dx;
-                double newY = y + dy;
+        double angle = Math.atan2(Game.player.getY() - this.getY(), Game.player.getX() - this.getX());
+        double perpendicular = angle + (Math.PI / 2) * strafeDirection;
+        double stepX = Math.cos(perpendicular) * strafeSpeed;
+        double stepY = Math.sin(perpendicular) * strafeSpeed;
 
-                if (World.isFree((int) newX, (int) y, 0)) {
-                        x = newX;
-                        moved = true;
-                }
+        if (!tryMove(stepX, stepY)) {
+            strafeDirection *= -1;
+            tryMove(Math.cos(angle) * chaseSpeed * 0.5, Math.sin(angle) * chaseSpeed * 0.5);
+            strafeTimer = 15;
+        }
+    }
 
-                if (World.isFree((int) x, (int) newY, 0)) {
-                        y = newY;
-                        moved = true;
-                }
+    private boolean tryMove(double dx, double dy) {
+        boolean moved = false;
+        double newX = x + dx;
+        double newY = y + dy;
 
-                return moved;
+        if (World.isFree((int) newX, (int) y, 0)) {
+            x = newX;
+            moved = true;
         }
 
-        private boolean hasLineOfSightToPlayer() {
-                int startX = this.getX() + this.mwidth / 2;
-                int startY = this.getY() + this.mheight / 2;
-                int endX = Game.player.getX() + Game.player.getWidth() / 2;
-                int endY = Game.player.getY() + Game.player.getHeight() / 2;
-
-                int steps = Math.max(Math.abs(endX - startX), Math.abs(endY - startY));
-                if (steps == 0) {
-                        return true;
-                }
-
-                double stepX = (endX - startX) / (double) steps;
-                double stepY = (endY - startY) / (double) steps;
-                double currentX = startX;
-                double currentY = startY;
-
-                for (int i = 0; i < steps; i++) {
-                        currentX += stepX;
-                        currentY += stepY;
-                        int tileX = (int) (currentX / World.TILE_SIZE);
-                        int tileY = (int) (currentY / World.TILE_SIZE);
-                        if (World.isWallTile(tileX, tileY)) {
-                                return false;
-                        }
-                }
-
-                return true;
+        if (World.isFree((int) x, (int) newY, 0)) {
+            y = newY;
+            moved = true;
         }
 
-        private void recalculatePathToPlayer() {
-                if (pathCooldown > 0) {
-                        return;
-                }
+        return moved;
+    }
 
-                Vector2i startNode = new Vector2i((int) (x / 16), (int) (y / 16));
-                Vector2i endNode = new Vector2i(Game.player.getX() / 16, Game.player.getY() / 16);
-                List<Node> newPath = AStar.findPath(Game.world, startNode, endNode);
-                if (newPath != null && !newPath.isEmpty()) {
-                        path = newPath;
-                }
+    private boolean hasLineOfSightToPlayer() {
+        int startX = this.getX() + this.mwidth / 2;
+        int startY = this.getY() + this.mheight / 2;
+        int endX = Game.player.getX() + Game.player.getWidth() / 2;
+        int endY = Game.player.getY() + Game.player.getHeight() / 2;
 
-                pathCooldown = PATH_RECALC_INTERVAL;
+        int steps = Math.max(Math.abs(endX - startX), Math.abs(endY - startY));
+        if (steps == 0) {
+            return true;
         }
 
-        private void chooseNewPatrolTarget() {
-                int attempts = 0;
-                while (attempts < 8) {
-                        attempts++;
-                        int radius = 4;
-                        int tileX = spawnTile.x + Game.rand.nextInt(radius * 2 + 1) - radius;
-                        int tileY = spawnTile.y + Game.rand.nextInt(radius * 2 + 1) - radius;
+        double stepX = (endX - startX) / (double) steps;
+        double stepY = (endY - startY) / (double) steps;
+        double currentX = startX;
+        double currentY = startY;
 
-                        if (!World.isValidTile(tileX, tileY) || World.isWallTile(tileX, tileY)) {
-                                continue;
-                        }
+        for (int i = 0; i < steps; i++) {
+            currentX += stepX;
+            currentY += stepY;
+            int tileX = (int) (currentX / World.TILE_SIZE);
+            int tileY = (int) (currentY / World.TILE_SIZE);
+            if (World.isWallTile(tileX, tileY)) {
+                return false;
+            }
+        }
 
-                        Vector2i startNode = new Vector2i((int) (x / 16), (int) (y / 16));
-                        Vector2i candidate = new Vector2i(tileX, tileY);
-                        List<Node> newPath = AStar.findPath(Game.world, startNode, candidate);
-                        if (newPath != null && !newPath.isEmpty()) {
-                                path = newPath;
-                                patrolTarget = candidate;
-                                patrolTimer = PATROL_INTERVAL;
-                                return;
-                        }
+        return true;
+    }
+
+    private void recalculatePathToPlayer() {
+        if (pathCooldown > 0) {
+            return;
+        }
+
+        Vector2i startNode = new Vector2i((int) (x / 16), (int) (y / 16));
+        Vector2i endNode = new Vector2i(Game.player.getX() / 16, Game.player.getY() / 16);
+        List<Node> newPath = AStar.findPath(Game.world, startNode, endNode);
+        if (newPath != null && !newPath.isEmpty()) {
+            path = newPath;
+        }
+
+        pathCooldown = PATH_RECALC_INTERVAL;
+    }
+
+    private void chooseNewPatrolTarget() {
+        int attempts = 0;
+        while (attempts < 8) {
+            attempts++;
+            int radius = 4;
+            int tileX = spawnTile.x + Game.rand.nextInt(radius * 2 + 1) - radius;
+            int tileY = spawnTile.y + Game.rand.nextInt(radius * 2 + 1) - radius;
+
+            if (!World.isValidTile(tileX, tileY) || World.isWallTile(tileX, tileY)) {
+                continue;
+            }
+
+            Vector2i startNode = new Vector2i((int) (x / 16), (int) (y / 16));
+            Vector2i candidate = new Vector2i(tileX, tileY);
+            List<Node> newPath = AStar.findPath(Game.world, startNode, candidate);
+            if (newPath != null && !newPath.isEmpty()) {
+                path = newPath;
+                patrolTarget = candidate;
+                patrolTimer = PATROL_INTERVAL;
+                return;
+            }
+        }
+
+        patrolTimer = PATROL_INTERVAL / 2;
+    }
+
+    private boolean reachedTile(Vector2i tile) {
+        if (tile == null) {
+            return false;
+        }
+        return this.getX() / 16 == tile.x && this.getY() / 16 == tile.y;
+    }
+
+    private void shootAtPlayer() {
+        if (attackCooldown > 0) {
+            return;
+        }
+
+        double angle = Math.atan2(Game.player.getY() - this.getY(), Game.player.getX() - this.getX());
+        spawnProjectile(angle, projectileSpeed, projectileDamage, projectileSize, projectileColor);
+
+        attackCooldown = attackCooldownBase - Game.rand.nextInt(Math.max(1, attackCooldownBase / 3));
+    }
+
+    private void spawnProjectile(double angle, double speed, double damage, int size, Color color) {
+        double dx = Math.cos(angle);
+        double dy = Math.sin(angle);
+        int originX = this.getX() + 8 - size / 2;
+        int originY = this.getY() + 8 - size / 2;
+        BulletShoot bullet = new BulletShoot(originX, originY, size, size, null, dx, dy, speed, damage, true, color);
+        bullet.setMask(0, 0, size, size);
+        Game.bullets.add(bullet);
+    }
+
+    public void destroySelf() {
+        Game.registerEnemyKill();
+        Game.enemies.remove(this);
+        Game.entities.remove(this);
+    }
+
+    public void collidingBullet() {
+        for (int i = 0; i < Game.bullets.size(); i++) {
+            Entity e = Game.bullets.get(i);
+            if (e instanceof BulletShoot) {
+                BulletShoot bullet = (BulletShoot) e;
+                if (bullet.isFromEnemy()) {
+                    continue;
                 }
+            }
 
-                patrolTimer = PATROL_INTERVAL / 2;
-        }
-
-        private boolean reachedTile(Vector2i tile) {
-                if (tile == null) {
-                        return false;
+            if (Entity.isColliding(this, e)) {
+                isDamaged = true;
+                double takenDamage = 1.0;
+                if (e instanceof BulletShoot) {
+                    BulletShoot projectile = (BulletShoot) e;
+                    takenDamage = projectile.getDamage();
                 }
-                return this.getX() / 16 == tile.x && this.getY() / 16 == tile.y;
+                life -= takenDamage;
+                Game.bullets.remove(i);
+                i--;
+                return;
+            }
         }
 
-        private void shootAtPlayer() {
-                if (attackCooldown > 0) {
-                        return;
-                }
+    }
 
-                double angle = Math.atan2(Game.player.getY() - this.getY(), Game.player.getX() - this.getX());
-                double dx = Math.cos(angle);
-                double dy = Math.sin(angle);
-                BulletShoot bullet = new BulletShoot(this.getX() + 8, this.getY() + 8, 4, 4, null, dx, dy, 4.0, 2.0,
-                                true);
-                bullet.setMask(0, 0, 4, 4);
-                Game.bullets.add(bullet);
-                attackCooldown = MAX_ATTACK_COOLDOWN - Game.rand.nextInt(20);
-        }
-        public void destroySelf() {
-                Game.registerEnemyKill();
-                Game.enemies.remove(this);
-                Game.entities.remove(this);
+    public boolean isCollidingWithPlayer() {
+        int enemyX = this.getX() + maskx;
+        int enemyY = this.getY() + masky;
+        int playerX = Game.player.getX();
+        int playerY = Game.player.getY();
+
+        return enemyX < playerX + 16 && enemyX + mwidth > playerX && enemyY < playerY + 16 && enemyY + mheight > playerY;
+    }
+
+    public void render(Graphics g) {
+        if (!isDamaged) {
+            g.drawImage(sprites[index], this.getX() + 4 - Camera.x, this.getY() + 4 - Camera.y, null);
+        } else {
+            g.drawImage(Entity.ENEMY_FEEDBACK, this.getX() + 4 - Camera.x, this.getY() + 4 - Camera.y, null);
         }
 
-	// Tirando dano com tiro
-        public void collidingBullet() {
-                for (int i = 0; i < Game.bullets.size(); i++) {
-                        Entity e = Game.bullets.get(i);
-                        if (e instanceof BulletShoot) {
-                                BulletShoot bullet = (BulletShoot) e;
-                                if (bullet.isFromEnemy()) {
-                                        continue;
-                                }
-                        }
-
-                        if (Entity.isColliding(this, e)) {
-                                isDamaged = true;
-                                double takenDamage = 1.0;
-                                if (e instanceof BulletShoot) {
-                                        BulletShoot projectile = (BulletShoot) e;
-                                        takenDamage = projectile.getDamage();
-                                }
-                                life -= takenDamage;
-                                Game.bullets.remove(i);
-                                i--;
-                                return;
-                        }
-                }
-
+        if (variant != Variant.SCOUT) {
+            Color aura = new Color(auraColor.getRed(), auraColor.getGreen(), auraColor.getBlue(), 120);
+            g.setColor(aura);
+            g.drawOval(this.getX() + 2 - Camera.x, this.getY() + 2 - Camera.y, 12, 12);
         }
-
-	// Fazer nenhum NPC colidir com o outro
-//			public boolean isColliding(int xNext, int yNext) {
-//				Rectangle enemyCurrent = new Rectangle(xNext+ maskx, yNext + masky,mwidth,mheight);
-//				for (int i = 0; i < Game.enemies.size(); i++) {
-//					Enemy e = Game.enemies.get(i);
-//					if (e == this)
-//						continue;
-//					Rectangle targetEnemy = new Rectangle(e.getX()+ maskx, e.getY()+ masky, mwidth,mheight);
-//					if (enemyCurrent.intersects(targetEnemy)) {
-//						return true;
-//					}
-//				}
-//
-//				return false;
-//			}
-
-	public boolean isCollidingWithPlayer() {
-		int enemyX = this.getX() + maskx;
-		int enemyY = this.getY() + masky;
-		int playerX = Game.player.getX();
-		int playerY = Game.player.getY();
-
-		return enemyX < playerX + 16 && enemyX + mwidth > playerX && enemyY < playerY + 16 && enemyY + mheight > playerY;
-	}
-
-	// Trocar a máscara quadrada para nao colidir
-//	Testar mascara de colisão
-//	public void render (Graphics g) {
-//		super.render(g);
-//		g.setColor(Color.blue);
-//		g.fillRect(this.getX()+maskx-Camera.x,this.getY()+ masky-Camera.y,maskw,masky);
-//	}
-
-	public void render(Graphics g) {
-		if (!isDamaged) {
-			// * Sempre que renderizar, tem que por a posição da Camera
-			g.drawImage(sprites[index], this.getX() + 4 - Camera.x, this.getY() + 4 - Camera.y, null);
-		} else {
-			g.drawImage(Entity.ENEMY_FEEDBACK, this.getX() + 4 - Camera.x, this.getY() + 4 - Camera.y, null);
-		}
-	}
+    }
 }

--- a/src/com/traduvertgames/graficos/UI.java
+++ b/src/com/traduvertgames/graficos/UI.java
@@ -14,17 +14,17 @@ import com.traduvertgames.main.Game;
 
 public class UI {
 
-        private static final int BAR_WIDTH = 96;
-        private static final int BAR_HEIGHT = 9;
+private static final int BAR_WIDTH = 128;
+private static final int BAR_HEIGHT = 10;
 
         public void render(Graphics g) {
                 Graphics2D g2 = (Graphics2D) g;
                 g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
-                int panelX = 6;
-                int panelY = 6;
-                int panelWidth = 116;
-                int panelHeight = 54;
+int panelX = 12;
+int panelY = 12;
+int panelWidth = 148;
+int panelHeight = 62;
                 g2.setColor(new Color(8, 12, 20, 190));
                 g2.fillRoundRect(panelX, panelY, panelWidth, panelHeight, 10, 10);
 
@@ -45,12 +45,17 @@ public class UI {
         public void renderOverlay(Graphics2D g2) {
                 g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
-                int screenWidth = Game.WIDTH * Game.SCALE;
-                int screenHeight = Game.HEIGHT * Game.SCALE;
+int screenWidth = Game.WIDTH * Game.SCALE;
+int screenHeight = Game.HEIGHT * Game.SCALE;
+int margin = 28;
+int statusWidth = 320;
+int scoreWidth = 320;
+int arsenalWidth = Math.min(screenWidth - margin * 2, 420);
+int arsenalHeight = 220;
 
-                drawStatusCard(g2, 20, 20, 280, 156);
-                drawScoreCard(g2, screenWidth - 260 - 20, 20, 260, 180);
-                drawArsenalCard(g2, 20, screenHeight - 220, 340, 200);
+drawStatusCard(g2, margin, margin, statusWidth, 176);
+drawScoreCard(g2, screenWidth - scoreWidth - margin, margin, scoreWidth, 196);
+drawArsenalCard(g2, margin, screenHeight - arsenalHeight - margin, arsenalWidth, arsenalHeight);
         }
 
         private void drawStatusCard(Graphics2D g2, int x, int y, int width, int height) {

--- a/src/com/traduvertgames/main/Game.java
+++ b/src/com/traduvertgames/main/Game.java
@@ -6,6 +6,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.FontMetrics;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
@@ -39,9 +40,9 @@ public class Game extends Canvas implements Runnable, KeyListener, MouseListener
 	public static JFrame frame;
 	private Thread thread;
 	private boolean isRunning = true;
-	public static final int WIDTH = 240;
-	public static final int HEIGHT = 160;
-	public static final int SCALE = 3;
+        public static final int WIDTH = 320;
+        public static final int HEIGHT = 192;
+        public static final int SCALE = 3;
 
         private static Game instance;
 
@@ -87,7 +88,7 @@ public class Game extends Canvas implements Runnable, KeyListener, MouseListener
                 rand = new Random();
 		addKeyListener(this);
 		addMouseListener(this);
-		setPreferredSize(new Dimension(WIDTH * SCALE, HEIGHT * SCALE));
+                setPreferredSize(new Dimension(WIDTH * SCALE, HEIGHT * SCALE));
 		initFrame();
 // Inicializando objetos;
 		ui = new UI();
@@ -360,31 +361,40 @@ public class Game extends Canvas implements Runnable, KeyListener, MouseListener
 		g.dispose();
 
                 g = bs.getDrawGraphics();
-                g.drawImage(image, 0, 0, WIDTH * SCALE, HEIGHT * SCALE, null);
+                int scaledWidth = WIDTH * SCALE;
+                int scaledHeight = HEIGHT * SCALE;
+                g.drawImage(image, 0, 0, scaledWidth, scaledHeight, null);
                 ui.renderOverlay((Graphics2D) g);
 
                 if (gameState == "GAMEOVER") {
                         Graphics2D g2 = (Graphics2D) g;
-                        g2.setColor(new Color(0, 0, 0, 100));
-                        g2.fillRect(0, 0, WIDTH * SCALE, HEIGHT * SCALE);
-			g.setFont(new Font("arial", Font.BOLD, 36));
-			g.setColor(Color.white);
-			g.drawString("Game Over", 290, 234);
-			g.setFont(new Font("arial", Font.BOLD, 32));
+                        g2.setColor(new Color(0, 0, 0, 120));
+                        g2.fillRect(0, 0, scaledWidth, scaledHeight);
+                        g.setFont(new Font("arial", Font.BOLD, 36));
+                        g.setColor(Color.white);
+                        drawCenteredString(g, "Game Over", scaledHeight / 2 - 50);
+                        g.setFont(new Font("arial", Font.BOLD, 28));
 
                         if (showMessageGameOver) {
-                                g.drawString(">Pressione Enter para reiniciar<", 130, 284);
+                                drawCenteredString(g, ">Pressione Enter para reiniciar<", scaledHeight / 2 + 4);
                         }
 
                         g.setFont(new Font("arial", Font.BOLD, 24));
-                        g.drawString("Pontuação final: " + Game.getScore(), 215, 334);
-                        g.drawString("Recorde: " + Game.getHighScore(), 215, 364);
-                        g.drawString("Melhor combo da partida: x" + Game.getBestComboThisRun(), 215, 394);
+                        drawCenteredString(g, "Pontuação final: " + Game.getScore(), scaledHeight / 2 + 52);
+                        drawCenteredString(g, "Recorde: " + Game.getHighScore(), scaledHeight / 2 + 82);
+                        drawCenteredString(g, "Melhor combo da partida: x" + Game.getBestComboThisRun(), scaledHeight / 2 + 112);
 
                 } else if (gameState == "MENU") {
                         menu.render(g);
                 }
                 bs.show();
+        }
+
+        private void drawCenteredString(Graphics g, String text, int baselineY) {
+                int width = WIDTH * SCALE;
+                FontMetrics metrics = g.getFontMetrics();
+                int textX = (width - metrics.stringWidth(text)) / 2;
+                g.drawString(text, textX, baselineY);
         }
 
         private void updateComboTimer() {

--- a/src/com/traduvertgames/world/World.java
+++ b/src/com/traduvertgames/world/World.java
@@ -39,11 +39,21 @@ public class World {
 						// Player
 						Game.player.setX(xx * 16);
 						Game.player.setY(yy * 16);
-					} else if (pixelAtual == 0xFFFF0000) {
-						// Enemy
-						Enemy en = new Enemy(xx * 16, yy * 16, 16, 16, Entity.ENEMY_EN);
-						Game.entities.add(en);
-						Game.enemies.add(en);
+} else if (pixelAtual == 0xFFFF0000) {
+// Enemy
+Enemy en = Enemy.spawnRandomVariant(xx * 16, yy * 16);
+Game.entities.add(en);
+Game.enemies.add(en);
+} else if (pixelAtual == 0xFF9C27B0) {
+// Teleporter elite
+Enemy en = new Enemy(xx * 16, yy * 16, 16, 16, Entity.ENEMY_EN, Enemy.Variant.TELEPORTER);
+Game.entities.add(en);
+Game.enemies.add(en);
+} else if (pixelAtual == 0xFF00BCD4) {
+// Artillery elite
+Enemy en = new Enemy(xx * 16, yy * 16, 16, 16, Entity.ENEMY_EN, Enemy.Variant.ARTILLERY);
+Game.entities.add(en);
+Game.enemies.add(en);
 					} else if (pixelAtual == 0xFFFF6A00) {
 						// Weapon
 						Game.entities.add(new Weapon(xx * 16, yy * 16, 16, 16, Entity.WEAPON_EN));


### PR DESCRIPTION
## Summary
- enlarge the base viewport to 320×192, center the game-over screen, and space the HUD panels to take advantage of the wider canvas
- introduce elite teleporter and artillery enemy variants with special behaviours, colored projectile support, and map spawn codes alongside the existing random spawns
- refresh the README with the new resolution and variant details

## Testing
- ./gradlew build *(fails: Could not determine java version from '21.0.2')*

------
https://chatgpt.com/codex/tasks/task_e_68f3eaf0272883319417025493761555