### PR TITLE
Add menu options for audio toggle and difficulty scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Os recursos, como sprites e áudio, estão localizados no diretório `res/`, enq
 - **Ataque:** `X` dispara projéteis enquanto houver munição e mana; o mouse também pode ser usado para mirar e atirar.【F:src/com/traduvertgames/main/Game.java†L452-L516】【F:src/com/traduvertgames/entities/Player.java†L101-L242】
 - **Troca de arma:** `Q`/`E` alternam entre as armas desbloqueadas e as teclas `1` a `4` selecionam diretamente um arquétipo específico.【F:src/com/traduvertgames/main/Game.java†L452-L497】【F:src/com/traduvertgames/entities/Player.java†L484-L512】
 - **Menu:** `Enter` confirma opções, `Esc` retorna ao menu/pausa, `T` salva o progresso quando em jogo.【F:src/com/traduvertgames/main/Game.java†L339-L372】【F:src/com/traduvertgames/main/Menu.java†L42-L103】
+- **Opções:** O submenu "Opções" do menu principal permite ligar ou desligar a música ambiente e alternar a dificuldade entre Fácil, Normal e Difícil; a configuração ajusta automaticamente a vida, mana, capacidade de munição e o dano sofrido pelo jogador.【F:src/com/traduvertgames/main/Menu.java†L25-L230】【F:src/com/traduvertgames/main/OptionsConfig.java†L1-L92】【F:src/com/traduvertgames/main/Game.java†L180-L357】【F:src/com/traduvertgames/entities/BulletShoot.java†L1-L60】【F:src/com/traduvertgames/entities/Enemy.java†L320-L420】
 
 ## Itens e recursos
 

--- a/docs/rotas-funcionalidades.md
+++ b/docs/rotas-funcionalidades.md
@@ -10,7 +10,8 @@ Este documento detalha o fluxo das principais rotas de execução do jogo, descr
 ## 2. Estados do jogo e fluxo de telas
 
 - O atributo `Game.gameState` define as rotas possíveis: `MENU`, `NORMAL` e `GAMEOVER`. Cada estado ativa lógicas diferentes em `update()` e `render()`, como interação com o menu, execução do jogo ou exibição da tela de derrota.【F:src/com/traduvertgames/main/Game.java†L53-L206】
-- No estado `MENU`, a classe `Menu` controla navegação (`up`, `down`, `enter`), habilita música ambiente e decide entre iniciar, continuar ou carregar o jogo salvo, redirecionando o fluxo para `NORMAL` ou finalizando a aplicação.【F:src/com/traduvertgames/main/Menu.java†L21-L103】
+- No estado `MENU`, a classe `Menu` controla navegação (`up`, `down`, `enter`), habilita música ambiente, abre o submenu de opções e decide entre iniciar, continuar ou carregar o jogo salvo, redirecionando o fluxo para `NORMAL` ou finalizando a aplicação.【F:src/com/traduvertgames/main/Menu.java†L23-L230】
+- O submenu "Opções" permite ativar/desativar a música (`OptionsConfig.toggleMusic`) e ciclar a dificuldade; `Game.applyDifficultyToPlayerStats()` recalcula vida, mana e munição máximas enquanto o dano sofrido é escalado via `Game.getDamageTakenMultiplier()`.【F:src/com/traduvertgames/main/Menu.java†L93-L230】【F:src/com/traduvertgames/main/OptionsConfig.java†L1-L92】【F:src/com/traduvertgames/main/Game.java†L200-L360】【F:src/com/traduvertgames/entities/BulletShoot.java†L1-L60】【F:src/com/traduvertgames/entities/Enemy.java†L320-L420】
 - Em `GAMEOVER`, o loop aguarda `Enter` para reiniciar o estado `NORMAL`, recarregando o mundo conforme o progresso salvo (se existir `save.txt`).【F:src/com/traduvertgames/main/Game.java†L124-L206】
 
 ## 3. Progressão de níveis

--- a/src/com/traduvertgames/entities/BulletShoot.java
+++ b/src/com/traduvertgames/entities/BulletShoot.java
@@ -48,7 +48,8 @@ public class BulletShoot extends Entity {
 
         if (fromEnemy) {
             if (Entity.isColliding(this, Game.player)) {
-                Game.player.life -= damage;
+                double scaledDamage = damage * Game.getDamageTakenMultiplier();
+                Game.player.life -= scaledDamage;
                 Game.player.damage = true;
                 Game.registerPlayerDamage();
                 Game.bullets.remove(this);

--- a/src/com/traduvertgames/entities/Enemy.java
+++ b/src/com/traduvertgames/entities/Enemy.java
@@ -401,7 +401,8 @@ public class Enemy extends Entity {
 
         if (isCollidingWithPlayer()) {
             if (Game.rand.nextInt(100) < 20) {
-                Game.player.life -= 2;
+                double scaledDamage = 2 * Game.getDamageTakenMultiplier();
+                Game.player.life -= scaledDamage;
                 Game.player.damage = true;
                 Game.registerPlayerDamage();
             }

--- a/src/com/traduvertgames/main/OptionsConfig.java
+++ b/src/com/traduvertgames/main/OptionsConfig.java
@@ -1,0 +1,105 @@
+package com.traduvertgames.main;
+
+public final class OptionsConfig {
+
+    public enum Difficulty {
+        EASY("Fácil", 1.25, 1.20, 0.8, 1.2),
+        NORMAL("Normal", 1.0, 1.0, 1.0, 1.0),
+        HARD("Difícil", 0.8, 0.85, 1.3, 0.9);
+
+        private final String displayName;
+        private final double lifeMultiplier;
+        private final double manaMultiplier;
+        private final double damageTakenMultiplier;
+        private final double weaponCapacityMultiplier;
+
+        Difficulty(String displayName, double lifeMultiplier, double manaMultiplier,
+                double damageTakenMultiplier, double weaponCapacityMultiplier) {
+            this.displayName = displayName;
+            this.lifeMultiplier = lifeMultiplier;
+            this.manaMultiplier = manaMultiplier;
+            this.damageTakenMultiplier = damageTakenMultiplier;
+            this.weaponCapacityMultiplier = weaponCapacityMultiplier;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public double getLifeMultiplier() {
+            return lifeMultiplier;
+        }
+
+        public double getManaMultiplier() {
+            return manaMultiplier;
+        }
+
+        public double getDamageTakenMultiplier() {
+            return damageTakenMultiplier;
+        }
+
+        public double getWeaponCapacityMultiplier() {
+            return weaponCapacityMultiplier;
+        }
+
+        public Difficulty next() {
+            Difficulty[] values = values();
+            int nextIndex = (ordinal() + 1) % values.length;
+            return values[nextIndex];
+        }
+    }
+
+    private static boolean musicEnabled = true;
+    private static Difficulty difficulty = Difficulty.NORMAL;
+
+    private OptionsConfig() {
+    }
+
+    public static boolean isMusicEnabled() {
+        return musicEnabled;
+    }
+
+    public static void toggleMusic() {
+        musicEnabled = !musicEnabled;
+        applyMusicPreference();
+    }
+
+    public static void applyMusicPreference() {
+        if (Sound.music == null) {
+            return;
+        }
+        if (musicEnabled) {
+            Sound.music.loop();
+        } else {
+            Sound.music.stop();
+        }
+    }
+
+    public static Difficulty getDifficulty() {
+        return difficulty;
+    }
+
+    public static void cycleDifficulty() {
+        difficulty = difficulty.next();
+        Game game = Game.getInstance();
+        if (game != null) {
+            game.applyDifficultyToPlayerStats();
+        }
+    }
+
+    public static double getDamageTakenMultiplier() {
+        return difficulty.getDamageTakenMultiplier();
+    }
+
+    public static double getLifeMultiplier() {
+        return difficulty.getLifeMultiplier();
+    }
+
+    public static double getManaMultiplier() {
+        return difficulty.getManaMultiplier();
+    }
+
+    public static double getWeaponCapacityMultiplier() {
+        return difficulty.getWeaponCapacityMultiplier();
+    }
+}

--- a/src/com/traduvertgames/main/Sound.java
+++ b/src/com/traduvertgames/main/Sound.java
@@ -1,66 +1,94 @@
 package com.traduvertgames.main;
 
-import java.io.*;
-import javax.sound.sampled.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.Clip;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.UnsupportedAudioFileException;
 
 public class Sound {
 
-	public static class Clips{
-		public Clip[] clips;
-		private int p;
-		private int count;
-		
-		public Clips(byte[] buffer, int count) throws LineUnavailableException, IOException, UnsupportedAudioFileException {
-			if(buffer == null)
-				return;
-			
-			clips = new Clip[count];
-			this.count = count;
-			
-			for(int i = 0; i < count; i++) {
-				clips[i] = AudioSystem.getClip();
-				clips[i].open(AudioSystem.getAudioInputStream(new ByteArrayInputStream(buffer)));
-			}
-		}
-		
-		public void play() {
-			if(clips == null) return;
-			clips[p].stop();
-			clips[p].setFramePosition(0);
-			clips[p].start();
-			p++;
-			if(p>=count) p = 0;
-		}
-		
-		public void loop() {
-			if(clips == null) return;
-			clips[p].loop(300);
-		}
+    public static class Clips {
+        private Clip[] clips;
+        private int p;
+        private int count;
 
-	}
-	
-	public static Clips music = load("/music.wav",1);
-	
-	private static Clips load(String name,int count) {
-		try {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			DataInputStream dis = new DataInputStream(Sound.class.getResourceAsStream(name));
-			
-			byte[] buffer = new byte[1024];
-			int read = 0;
-			while((read = dis.read(buffer)) >= 0) {
-				baos.write(buffer,0,read);
-			}
-			dis.close();
-			byte[] data = baos.toByteArray();
-			return new Clips(data,count);
-		}catch(Exception e) {
-			try {
-				return new Clips(null,0);
-			}catch(Exception ee) {
-				return null;
-			}
-		}
-	}
-	
+        public Clips(byte[] buffer, int count)
+                throws LineUnavailableException, IOException, UnsupportedAudioFileException {
+            if (buffer == null) {
+                return;
+            }
+
+            clips = new Clip[count];
+            this.count = count;
+
+            for (int i = 0; i < count; i++) {
+                clips[i] = AudioSystem.getClip();
+                clips[i].open(AudioSystem.getAudioInputStream(new ByteArrayInputStream(buffer)));
+            }
+        }
+
+        public void play() {
+            if (clips == null) {
+                return;
+            }
+            clips[p].stop();
+            clips[p].setFramePosition(0);
+            clips[p].start();
+            p++;
+            if (p >= count) {
+                p = 0;
+            }
+        }
+
+        public void loop() {
+            if (clips == null) {
+                return;
+            }
+            clips[p].stop();
+            clips[p].setFramePosition(0);
+            clips[p].loop(300);
+        }
+
+        public void stop() {
+            if (clips == null) {
+                return;
+            }
+            for (Clip clip : clips) {
+                if (clip == null) {
+                    continue;
+                }
+                clip.stop();
+                clip.setFramePosition(0);
+            }
+        }
+    }
+
+    public static Clips music = load("/music.wav", 1);
+
+    private static Clips load(String name, int count) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            DataInputStream dis = new DataInputStream(Sound.class.getResourceAsStream(name));
+
+            byte[] buffer = new byte[1024];
+            int read = 0;
+            while ((read = dis.read(buffer)) >= 0) {
+                baos.write(buffer, 0, read);
+            }
+            dis.close();
+            byte[] data = baos.toByteArray();
+            return new Clips(data, count);
+        } catch (Exception e) {
+            try {
+                return new Clips(null, 0);
+            } catch (Exception ee) {
+                return null;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a configurable Options submenu that toggles music playback and cycles difficulty before starting or resuming the game
- scale player resources and incoming damage according to the selected difficulty using a new OptionsConfig helper
- refresh menu rendering, audio helpers, and documentation to describe the new settings

## Testing
- ./gradlew build *(fails: Could not determine java version from '21.0.2')*


------
https://chatgpt.com/codex/tasks/task_e_68f5a23ff7ac8331bac03becc618d572