### PR TITLE
Fix exit confirmation and adjust collision tolerance

### DIFF
--- a/src/com/traduvertgames/main/Menu.java
+++ b/src/com/traduvertgames/main/Menu.java
@@ -112,8 +112,14 @@ public class Menu {
                                 currentOption = 0;
                                 break;
                         case OPTION_EXIT:
-                                JOptionPane.showConfirmDialog(null, "Deseja realmente sair?", "Fechar o jogo", currentOption);
-                                System.exit(1);
+                                int result = JOptionPane.showConfirmDialog(
+                                                null,
+                                                "Deseja realmente sair?",
+                                                "Fechar o jogo",
+                                                JOptionPane.YES_NO_OPTION);
+                                if (result == JOptionPane.YES_OPTION) {
+                                        System.exit(0);
+                                }
                                 break;
                         default:
                                 break;

--- a/src/com/traduvertgames/world/World.java
+++ b/src/com/traduvertgames/world/World.java
@@ -102,34 +102,42 @@ Game.enemies.add(en);
 	}
 
 	public static boolean isFree(int xNext,int yNext, int zplayer) {
-		int x1 = xNext / TILE_SIZE;
-		int y1 = yNext / TILE_SIZE;
-		
-		int x2 = (xNext+TILE_SIZE-1) / TILE_SIZE;
-		int y2 = yNext / TILE_SIZE;
-		
-		int x3 = xNext / TILE_SIZE;
-		int y3 = (yNext+TILE_SIZE-1) / TILE_SIZE;
-		
-		int x4 = (xNext+TILE_SIZE-1) / TILE_SIZE;
-		int y4 = (yNext+TILE_SIZE-1) / TILE_SIZE;
+		final int margin = 1;
+
+		int adjustedX1 = xNext + margin;
+		int adjustedY1 = yNext + margin;
+
+		int adjustedX2 = xNext + TILE_SIZE - 1 - margin;
+		int adjustedY2 = yNext + margin;
+
+		int adjustedX3 = xNext + margin;
+		int adjustedY3 = yNext + TILE_SIZE - 1 - margin;
+
+		int adjustedX4 = xNext + TILE_SIZE - 1 - margin;
+		int adjustedY4 = yNext + TILE_SIZE - 1 - margin;
+
 		try {
-			if( !((tiles[x1+(y1*World.WIDTH)] instanceof WallTile) ||
-					(tiles[x2+(y2*World.WIDTH)] instanceof WallTile) || 
-					(tiles[x3+(y3*World.WIDTH)] instanceof WallTile) || 
-					(tiles[x4+(y4*World.WIDTH)] instanceof WallTile))) {
-				return true;
-			}
-		}catch(ArrayIndexOutOfBoundsException ex) {
-//			System.out.println("Saiu do mapa");
+			int x1 = adjustedX1 / TILE_SIZE;
+			int y1 = adjustedY1 / TILE_SIZE;
+
+			int x2 = adjustedX2 / TILE_SIZE;
+			int y2 = adjustedY2 / TILE_SIZE;
+
+			int x3 = adjustedX3 / TILE_SIZE;
+			int y3 = adjustedY3 / TILE_SIZE;
+
+			int x4 = adjustedX4 / TILE_SIZE;
+			int y4 = adjustedY4 / TILE_SIZE;
+
+			boolean hitsWall = (tiles[x1 + (y1 * World.WIDTH)] instanceof WallTile)
+						|| (tiles[x2 + (y2 * World.WIDTH)] instanceof WallTile)
+						|| (tiles[x3 + (y3 * World.WIDTH)] instanceof WallTile)
+						|| (tiles[x4 + (y4 * World.WIDTH)] instanceof WallTile);
+
+			return !hitsWall;
+		} catch (ArrayIndexOutOfBoundsException ex) {
+			return false;
 		}
-		
-		
-//		Posibilita pular pelas paredes
-//		if(zplayer>0) {
-//			return true;
-//		}
-		return false;
 	}
 	
         public static void restartGame(String level) {


### PR DESCRIPTION
## Summary
- update the exit option to prompt with a yes/no dialog before closing the game
- relax tile collision checks with a small margin so the player can move through single-tile passages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f689943f608331b7419acbede8e236