### PR TITLE
Fix invalid option type in exit confirmation dialog

### DIFF
--- a/src/com/traduvertgames/main/Menu.java
+++ b/src/com/traduvertgames/main/Menu.java
@@ -116,7 +116,8 @@ public class Menu {
                                                 null,
                                                 "Deseja realmente sair?",
                                                 "Fechar o jogo",
-                                                JOptionPane.YES_NO_OPTION);
+                                                JOptionPane.YES_NO_OPTION,
+                                                JOptionPane.QUESTION_MESSAGE);
                                 if (result == JOptionPane.YES_OPTION) {
                                         System.exit(0);
                                 }


### PR DESCRIPTION
## Summary
- ensure the exit confirmation dialog requests a valid JOptionPane option set by using the question message type

## Testing
- ./gradlew test *(fails: Gradle wrapper does not support JDK 21 and aborts with `Could not determine java version from '21.0.2'.`)*

------
https://chatgpt.com/codex/tasks/task_e_68f694f796008331ae1596a6653810b7