### PR TITLE
Add pygame-based Python port of the game

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ O jogo grava vida, mana, escudo, quantidade de munição (arma), inimigos derrot
 
 ## Compilação e execução
 
+
+## Porta em Python (pygame)
+
+Uma reimplementação completa em Python está disponível no diretório `python_port/`. Ela replica o fluxo de jogo principal (loop, estados, HUD, inimigos e itens) utilizando pygame e reutiliza os mesmos arquivos de mapa presentes em `res/`. Para experimentar:
+
+```bash
+pip install -e ./python_port
+python -m python_port.main --level 1
+```
+
+Os mapas (`res/level*.png`) continuam sendo gerados pelo script `tools/generate_maps.py`, e a janela renderiza na mesma resolução interna (384×216) escalada para 1 152×648 pixels. A dificuldade inicial pode ser alterada com `--difficulty easy|normal|hard`.
+
+
 Você pode compilar e executar o projeto utilizando o Gradle wrapper:
 
 ```

--- a/python_port/pyproject.toml
+++ b/python_port/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "first-game-python"
+version = "0.1.0"
+description = "Porta em Python do First Game in Java, utilizando pygame."
+authors = [{ name = "First Game Maintainers" }]
+requires-python = ">=3.9"
+dependencies = [
+    "pygame>=2.5",
+    "Pillow>=10.0",
+]
+
+[project.scripts]
+first-game-python = "python_port.main:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/python_port/python_port/__init__.py
+++ b/python_port/python_port/__init__.py
@@ -1,0 +1,4 @@
+"""Pacote da porta em Python do First Game in Java."""
+from .game import Game
+
+__all__ = ["Game"]

--- a/python_port/python_port/entities.py
+++ b/python_port/python_port/entities.py
@@ -1,0 +1,365 @@
+"""Entidades principais utilizadas no jogo em Python."""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Callable, Dict, TYPE_CHECKING
+
+import pygame
+
+from . import settings
+
+if TYPE_CHECKING:
+    from .game import Game
+
+def make_surface(color: tuple[int, int, int], size: tuple[int, int] = (settings.TILE_SIZE, settings.TILE_SIZE)) -> pygame.Surface:
+    surface = pygame.Surface(size)
+    surface.fill(color)
+    return surface.convert_alpha()
+
+
+class Entity:
+    def __init__(self, x: int, y: int, width: int = settings.TILE_SIZE, height: int = settings.TILE_SIZE, *, color: tuple[int, int, int] = settings.COLOR_FLOOR):
+        self.rect = pygame.Rect(x, y, width, height)
+        self.position = pygame.Vector2(float(x), float(y))
+        self.velocity = pygame.Vector2(0, 0)
+        self.sprite = make_surface(color, (width, height))
+        self.dead = False
+        self.z_index = 0
+
+    def update(self, game: "Game", dt: float) -> None:  # pragma: no cover - interface
+        pass
+
+    def draw(self, surface: pygame.Surface) -> None:
+        surface.blit(self.sprite, self.rect)
+
+    def sync_rect(self) -> None:
+        self.rect.topleft = (int(self.position.x), int(self.position.y))
+
+
+class LivingEntity(Entity):
+    def __init__(self, x: int, y: int, width: int, height: int, *, color: tuple[int, int, int], max_health: float):
+        super().__init__(x, y, width, height, color=color)
+        self.max_health = max_health
+        self.health = max_health
+        self.shield = 0.0
+        self.max_shield = 0.0
+        self.invulnerability_timer = 0.0
+
+    def take_damage(self, amount: float, *, ignore_shield: bool = False) -> None:
+        if self.invulnerability_timer > 0:
+            return
+        remaining = amount
+        if self.shield > 0 and not ignore_shield:
+            absorbed = min(self.shield, remaining)
+            self.shield -= absorbed
+            remaining -= absorbed
+        if remaining > 0:
+            self.health -= remaining
+            if self.health <= 0:
+                self.dead = True
+        self.invulnerability_timer = 0.2
+
+    def heal(self, amount: float) -> None:
+        self.health = min(self.max_health, self.health + amount)
+
+    def restore_shield(self, amount: float) -> None:
+        self.shield = min(self.max_shield, self.shield + amount)
+
+    def update(self, game: "Game", dt: float) -> None:
+        if self.invulnerability_timer > 0:
+            self.invulnerability_timer = max(0.0, self.invulnerability_timer - dt)
+
+
+class Projectile(Entity):
+    def __init__(self, x: int, y: int, direction: pygame.Vector2, speed: float, damage: float, owner: str, *, color: tuple[int, int, int]):
+        super().__init__(x, y, 6, 6, color=color)
+        direction = direction if direction.length_squared() > 0 else pygame.Vector2(1, 0)
+        direction = direction.normalize()
+        self.velocity = direction * speed
+        self.damage = damage
+        self.owner = owner
+
+    def update(self, game: "Game", dt: float) -> None:
+        self.position += self.velocity * dt
+        self.sync_rect()
+        if (self.rect.right < 0 or self.rect.left > settings.INTERNAL_WIDTH or self.rect.bottom < 0 or self.rect.top > settings.INTERNAL_HEIGHT):
+            self.dead = True
+            return
+        if game.world.rect_collides(self.rect):
+            self.dead = True
+            return
+
+        if self.owner == "player":
+            for enemy in list(game.enemies):
+                if self.rect.colliderect(enemy.rect):
+                    enemy.take_damage(self.damage)
+                    self.dead = True
+                    if enemy.dead:
+                        game.on_enemy_killed(enemy)
+                    return
+        else:
+            player = game.player
+            if self.rect.colliderect(player.rect):
+                player.take_damage(self.damage)
+                self.dead = True
+
+
+class Player(LivingEntity):
+    def __init__(self, x: int, y: int, difficulty: settings.Difficulty):
+        stats = difficulty.player_stats
+        super().__init__(x, y, settings.TILE_SIZE, settings.TILE_SIZE, color=settings.COLOR_PLAYER, max_health=stats["max_health"])
+        self.max_shield = stats["max_shield"]
+        self.shield = self.max_shield * 0.6
+        self.max_energy = stats["max_energy"]
+        self.energy = self.max_energy
+        self.max_ammo = stats["max_ammo"]
+        self.ammo = self.max_ammo // 2
+        self.speed = 120
+        self.sprint_speed = 180
+        self.reload_rate = 30
+        self.energy_regen = 20
+        self.shoot_cooldown = 0.0
+        self.combo_bonus = 0
+        self.facing = pygame.Vector2(1, 0)
+
+    def handle_input(self, keys: pygame.key.ScancodeWrapper, dt: float, world: WorldLike) -> None:
+        direction = pygame.Vector2(0, 0)
+        if keys[pygame.K_w] or keys[pygame.K_UP]:
+            direction.y -= 1
+        if keys[pygame.K_s] or keys[pygame.K_DOWN]:
+            direction.y += 1
+        if keys[pygame.K_a] or keys[pygame.K_LEFT]:
+            direction.x -= 1
+        if keys[pygame.K_d] or keys[pygame.K_RIGHT]:
+            direction.x += 1
+        if direction.length_squared() > 0:
+            direction = direction.normalize()
+            self.facing = direction
+        speed = self.speed
+        if keys[pygame.K_LSHIFT] or keys[pygame.K_RSHIFT]:
+            speed = self.sprint_speed
+        dx = direction.x * speed * dt
+        dy = direction.y * speed * dt
+        self._move(dx, dy, world)
+
+    def _move(self, dx: float, dy: float, world: WorldLike) -> None:
+        self.position.x += dx
+        self.sync_rect()
+        if world.rect_collides(self.rect):
+            self.position.x -= dx
+            self.sync_rect()
+        self.position.y += dy
+        self.sync_rect()
+        if world.rect_collides(self.rect):
+            self.position.y -= dy
+            self.sync_rect()
+
+    def update(self, game: "Game", dt: float) -> None:
+        super().update(game, dt)
+        self.energy = min(self.max_energy, self.energy + self.energy_regen * dt)
+        self.ammo = min(self.max_ammo, self.ammo + self.reload_rate * dt * 0.1)
+        if self.shoot_cooldown > 0:
+            self.shoot_cooldown = max(0.0, self.shoot_cooldown - dt)
+
+    def try_shoot(self, game: "Game") -> None:
+        if self.shoot_cooldown > 0:
+            return
+        if self.energy < 5 or self.ammo <= 0:
+            return
+        self.energy -= 5
+        self.ammo -= 1
+        self.shoot_cooldown = 0.25
+        direction = self.facing.normalize() if self.facing.length_squared() > 0 else pygame.Vector2(1, 0)
+        origin = pygame.Vector2(self.rect.center)
+        projectile = Projectile(int(origin.x), int(origin.y), direction, speed=360, damage=18, owner="player", color=(255, 240, 170))
+        game.projectiles.append(projectile)
+
+
+@dataclass
+class EnemyVariant:
+    name: str
+    speed: float
+    health: float
+    attack_cooldown: float
+    projectile_speed: float
+    projectile_damage: float
+    behavior: str = "chaser"
+
+
+ENEMY_VARIANTS: Dict[str, EnemyVariant] = {
+    "scout": EnemyVariant("Scout", speed=80, health=60, attack_cooldown=1.4, projectile_speed=220, projectile_damage=8, behavior="chaser"),
+    "teleporter": EnemyVariant("Teleporter", speed=70, health=65, attack_cooldown=2.5, projectile_speed=260, projectile_damage=10, behavior="teleport"),
+    "artillery": EnemyVariant("Artillery", speed=40, health=80, attack_cooldown=1.8, projectile_speed=320, projectile_damage=12, behavior="ranged"),
+    "warden": EnemyVariant("Warden", speed=55, health=140, attack_cooldown=2.2, projectile_speed=260, projectile_damage=14, behavior="tank"),
+    "sentinel": EnemyVariant("Sentinel", speed=65, health=120, attack_cooldown=2.0, projectile_speed=280, projectile_damage=12, behavior="support"),
+    "ravager": EnemyVariant("Ravager", speed=110, health=90, attack_cooldown=1.1, projectile_speed=300, projectile_damage=10, behavior="charger"),
+    "warbringer": EnemyVariant("Warbringer", speed=75, health=200, attack_cooldown=1.0, projectile_speed=360, projectile_damage=16, behavior="boss"),
+    "overseer": EnemyVariant("Overseer", speed=60, health=220, attack_cooldown=1.6, projectile_speed=320, projectile_damage=14, behavior="summoner"),
+}
+
+
+class Enemy(LivingEntity):
+    def __init__(self, x: int, y: int, variant: EnemyVariant, *, difficulty: settings.Difficulty):
+        adjusted_health = variant.health * difficulty.enemy_spawn_multiplier
+        super().__init__(x, y, settings.TILE_SIZE, settings.TILE_SIZE, color=settings.COLOR_ENEMY, max_health=adjusted_health)
+        self.variant = variant
+        self.attack_timer = random.uniform(0.0, variant.attack_cooldown)
+        self.teleport_timer = 0.0
+        self.z_index = 1
+
+    def update(self, game: "Game", dt: float) -> None:
+        super().update(game, dt)
+        player_vector = pygame.Vector2(game.player.rect.center)
+        pos = pygame.Vector2(self.rect.center)
+        direction = player_vector - pos
+        distance = direction.length()
+        if distance == 0:
+            direction = pygame.Vector2(1, 0)
+            distance = 0.1
+        else:
+            direction = direction.normalize()
+
+        speed = self.variant.speed
+        if self.variant.behavior == "charger" and distance < 160:
+            speed *= 1.5
+        elif self.variant.behavior == "tank":
+            speed *= 0.7
+
+        movement = direction * speed * dt
+        self.position += movement
+        self.sync_rect()
+        if game.world.rect_collides(self.rect):
+            self.position -= pygame.Vector2(movement.x, 0)
+            self.sync_rect()
+        if game.world.rect_collides(self.rect):
+            self.position -= pygame.Vector2(0, movement.y)
+            self.sync_rect()
+
+        self.attack_timer -= dt
+        if self.attack_timer <= 0:
+            self.attack_timer = self.variant.attack_cooldown
+            self.perform_attack(game, direction)
+
+        if self.variant.behavior == "teleport":
+            self.teleport_timer -= dt
+            if self.teleport_timer <= 0 and distance < 120:
+                self.teleport_behind_player(game)
+                self.teleport_timer = 3.5
+
+    def perform_attack(self, game: "Game", direction: pygame.Vector2) -> None:
+        if self.variant.behavior in {"ranged", "boss", "support"}:
+            self.fire_projectile(game, direction)
+        elif self.variant.behavior == "summoner":
+            self.fire_projectile(game, direction)
+            if random.random() < 0.35:
+                game.spawn_enemy(self.rect.x, self.rect.y, "scout")
+        else:
+            if self.rect.colliderect(game.player.rect.inflate(12, 12)):
+                game.player.take_damage(self.variant.projectile_damage * 0.6)
+
+    def fire_projectile(self, game: "Game", direction: pygame.Vector2) -> None:
+        projectile = Projectile(self.rect.centerx, self.rect.centery, direction, self.variant.projectile_speed, self.variant.projectile_damage, owner="enemy", color=(255, 120, 120))
+        game.projectiles.append(projectile)
+
+    def teleport_behind_player(self, game: "Game") -> None:
+        player = game.player
+        offset = pygame.Vector2(player.facing)
+        if offset.length_squared() == 0:
+            offset = pygame.Vector2(1, 0)
+        teleport_position = pygame.Vector2(player.rect.center) - offset * 40
+        self.position.x = max(0, min(settings.INTERNAL_WIDTH - self.rect.width, teleport_position.x))
+        self.position.y = max(0, min(settings.INTERNAL_HEIGHT - self.rect.height, teleport_position.y))
+        self.sync_rect()
+
+
+class Pickup(Entity):
+    def __init__(self, x: int, y: int, effect: Callable[["Game", Player], None], color: tuple[int, int, int]):
+        super().__init__(x, y, settings.TILE_SIZE, settings.TILE_SIZE, color=color)
+        self.effect = effect
+        self.z_index = -1
+
+    def update(self, game: "Game", dt: float) -> None:
+        if self.rect.colliderect(game.player.rect):
+            self.effect(game, game.player)
+            self.dead = True
+
+
+# Tipagem auxiliar para evitar import circular.
+class WorldLike:
+    def rect_collides(self, rect: tuple[int, int, int, int]) -> bool:  # pragma: no cover - protocolo
+        ...
+
+
+def create_pickup(kind: str, x: int, y: int) -> Pickup:
+    def heal(game: "Game", player: Player, amount: float) -> None:
+        player.heal(amount)
+        game.add_message("+Vida", player.rect.midtop)
+
+    def refill_shield(game: "Game", player: Player, amount: float) -> None:
+        player.restore_shield(amount)
+        game.add_message("+Escudo", player.rect.midtop)
+
+    def refill_energy(game: "Game", player: Player, amount: float) -> None:
+        player.energy = min(player.max_energy, player.energy + amount)
+        game.add_message("+Energia", player.rect.midtop)
+
+    def refill_ammo(game: "Game", player: Player, amount: float) -> None:
+        player.ammo = min(player.max_ammo, player.ammo + amount)
+        game.add_message("+Munição", player.rect.midtop)
+
+    def overclock(game: "Game", player: Player) -> None:
+        refill_energy(game, player, 60)
+        refill_ammo(game, player, 30)
+        game.add_message("Overclock!", player.rect.midtop)
+
+    def notify(label: str) -> Callable[["Game", Player], None]:
+        def _inner(g: "Game", player: Player) -> None:
+            g.increment_quest_progress(label)
+            g.add_message(label, player.rect.midtop)
+        return _inner
+
+    effects: Dict[str, Callable[["Game", Player], None]] = {
+        "lifepack": lambda g, p: heal(g, p, 30),
+        "nanomedkit": lambda g, p: heal(g, p, 60),
+        "shield": lambda g, p: refill_shield(g, p, 40),
+        "energy": lambda g, p: refill_energy(g, p, 40),
+        "overclock": overclock,
+        "ammo": lambda g, p: refill_ammo(g, p, 50),
+        "weapon": lambda g, p: refill_ammo(g, p, 70),
+        "quest_item": notify("Artefato"),
+        "quest_beacon": notify("Farol"),
+        "quest_npc": notify("Sobrevivente"),
+        "engineer": notify("Engenheiro"),
+        "researcher": notify("Pesquisador"),
+        "data_core": notify("Protocolo"),
+        "teleport_pad": lambda g, p: g.activate_teleport(),
+    }
+
+    colors: Dict[str, tuple[int, int, int]] = {
+        "lifepack": settings.COLOR_PICKUP,
+        "nanomedkit": (255, 100, 100),
+        "shield": settings.COLOR_SHIELD,
+        "energy": settings.COLOR_ENERGY,
+        "overclock": (0, 229, 255),
+        "ammo": (255, 220, 64),
+        "weapon": (255, 106, 0),
+        "quest_item": (255, 193, 7),
+        "quest_beacon": (76, 175, 80),
+        "quest_npc": (121, 85, 72),
+        "engineer": (255, 183, 77),
+        "researcher": (126, 87, 194),
+        "data_core": (0, 172, 193),
+        "teleport_pad": (103, 58, 183),
+    }
+
+    if kind not in effects:
+        raise ValueError(f"Pickup desconhecido: {kind}")
+
+    effect = effects[kind]
+    return Pickup(x, y, effect, colors[kind])
+
+
+def create_enemy(kind: str, x: int, y: int, difficulty: settings.Difficulty) -> Enemy:
+    variant = ENEMY_VARIANTS.get(kind, ENEMY_VARIANTS["scout"])
+    return Enemy(x, y, variant, difficulty=difficulty)

--- a/python_port/python_port/game.py
+++ b/python_port/python_port/game.py
@@ -1,0 +1,273 @@
+"""Loop principal da versão Python do jogo."""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import List
+
+import pygame
+
+from . import settings
+from .entities import Player, create_enemy, create_pickup, Enemy, Projectile, Pickup
+from .ui import FloatingMessage, draw_hud
+from .world import World
+
+
+@dataclass
+class QuestTracker:
+    title: str
+    target: int
+    progress: int = 0
+
+    def increment(self) -> None:
+        self.progress += 1
+
+    @property
+    def completed(self) -> bool:
+        return self.progress >= self.target
+
+    def render_text(self) -> str:
+        return f"{self.title}: {self.progress}/{self.target}"
+
+
+class Game:
+    def __init__(self, *, difficulty: settings.Difficulty = settings.Difficulty.NORMAL, start_level: int = 1):
+        pygame.init()
+        pygame.mixer.quit()  # Evita erros em ambientes sem áudio.
+        self.clock = pygame.time.Clock()
+        self.screen = pygame.display.set_mode((settings.DISPLAY_WIDTH, settings.DISPLAY_HEIGHT))
+        pygame.display.set_caption("First Game in Python")
+        self.canvas = pygame.Surface((settings.INTERNAL_WIDTH, settings.INTERNAL_HEIGHT))
+        self.difficulty = difficulty
+        self.state = settings.GameState.MENU
+        self.level = start_level
+        self.score = 0
+        self.combo_multiplier = 1
+        self.combo_timer = 0.0
+        self.messages: List[FloatingMessage] = []
+        self.quest: QuestTracker | None = None
+        self.teleport_ready = False
+        self.font_large = pygame.font.Font(None, 36)
+        self.font_small = pygame.font.Font(None, 24)
+
+        self.world: World | None = None
+        self.player: Player | None = None
+        self.enemies: List[Enemy] = []
+        self.pickups: List[Pickup] = []
+        self.projectiles: List[Projectile] = []
+
+    def load_level(self, level: int) -> None:
+        self.world = World.from_level(level)
+        self.player = Player(self.world.player_spawn[0], self.world.player_spawn[1], self.difficulty)
+        self.player.sync_rect()
+        self.enemies = []
+        self.pickups = []
+        self.projectiles = []
+        quest_targets = 0
+        for spawn in self.world.spawns:
+            x, y = spawn.position
+            if spawn.kind == "enemy":
+                self.spawn_enemy(x, y, spawn.variant or "scout")
+            else:
+                pickup = create_pickup(spawn.kind, x, y)
+                self.pickups.append(pickup)
+                if spawn.kind in {"quest_item", "quest_beacon", "quest_npc", "engineer", "researcher", "data_core"}:
+                    quest_targets += 1
+        if quest_targets:
+            self.quest = QuestTracker("Missão", quest_targets)
+        else:
+            self.quest = None
+        self.teleport_ready = False
+        self.combo_multiplier = 1
+        self.combo_timer = 0
+        self.score = 0
+        self.messages.clear()
+
+    def spawn_enemy(self, x: int, y: int, variant: str) -> None:
+        enemy = create_enemy(variant, x, y, self.difficulty)
+        enemy.sync_rect()
+        self.enemies.append(enemy)
+
+    def add_message(self, text: str, position: tuple[int, int]) -> None:
+        message = FloatingMessage(text=text, position=pygame.Vector2(position))
+        self.messages.append(message)
+
+    def on_enemy_killed(self, enemy: Enemy) -> None:
+        base_score = 100 + enemy.variant.health * 0.5
+        self.score += int(base_score * self.combo_multiplier)
+        self.combo_multiplier += settings.COMBO_INCREMENT
+        self.combo_timer = settings.COMBO_TIMEOUT
+        if random.random() < 0.25:
+            pickup_kind = random.choice(["lifepack", "ammo", "energy", "shield"])
+            pickup = create_pickup(pickup_kind, enemy.rect.x, enemy.rect.y)
+            self.pickups.append(pickup)
+        self.add_message("Combo +", enemy.rect.midtop)
+
+    def increment_quest_progress(self, label: str) -> None:
+        if self.quest:
+            self.quest.increment()
+            if self.quest.completed:
+                self.add_message("Objetivo concluído!", (settings.INTERNAL_WIDTH // 2 - 40, 40))
+
+    def activate_teleport(self) -> None:
+        self.teleport_ready = True
+        self.add_message("Teleporte pronto", (settings.INTERNAL_WIDTH // 2 - 40, 60))
+
+    @property
+    def quest_status(self) -> str:
+        if self.teleport_ready:
+            return "Ative o teleporte!"
+        if not self.quest:
+            return "Explore a estação"
+        return self.quest.render_text()
+
+    def update_messages(self, dt: float) -> None:
+        for message in list(self.messages):
+            message.update(dt)
+            if not message.alive:
+                self.messages.remove(message)
+
+    def start_game(self) -> None:
+        self.load_level(self.level)
+        self.state = settings.GameState.PLAYING
+
+    def reset_to_menu(self) -> None:
+        self.state = settings.GameState.MENU
+
+    def handle_menu_event(self, event: pygame.event.Event) -> None:
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_RETURN:
+                self.start_game()
+            elif event.key == pygame.K_ESCAPE:
+                pygame.event.post(pygame.event.Event(pygame.QUIT))
+            elif event.key == pygame.K_TAB:
+                options = list(settings.Difficulty)
+                idx = options.index(self.difficulty)
+                self.difficulty = options[(idx + 1) % len(options)]
+
+    def handle_playing_event(self, event: pygame.event.Event) -> None:
+        if not self.player:
+            return
+        if event.type == pygame.KEYDOWN:
+            if event.key == pygame.K_ESCAPE:
+                self.reset_to_menu()
+            elif event.key == pygame.K_x:
+                self.player.try_shoot(self)
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            self.player.try_shoot(self)
+
+    def update_gameplay(self, dt: float) -> None:
+        if not self.player or not self.world:
+            return
+        keys = pygame.key.get_pressed()
+        self.player.handle_input(keys, dt, self.world)
+        self.player.update(self, dt)
+
+        mouse_buttons = pygame.mouse.get_pressed()
+        if keys[pygame.K_x] or mouse_buttons[0]:
+            self.player.try_shoot(self)
+
+        for enemy in list(self.enemies):
+            enemy.update(self, dt)
+            if enemy.dead:
+                self.enemies.remove(enemy)
+
+        for pickup in list(self.pickups):
+            pickup.update(self, dt)
+            if pickup.dead:
+                self.pickups.remove(pickup)
+
+        for projectile in list(self.projectiles):
+            projectile.update(self, dt)
+            if projectile.dead:
+                self.projectiles.remove(projectile)
+
+        if self.player.dead:
+            self.state = settings.GameState.GAME_OVER
+            self.add_message("Você foi derrotado", (settings.INTERNAL_WIDTH // 2 - 60, settings.INTERNAL_HEIGHT // 2))
+
+        if self.combo_multiplier > 1:
+            self.combo_timer -= dt
+            if self.combo_timer <= 0:
+                self.combo_multiplier = 1
+
+        self.update_messages(dt)
+
+        if self.quest and self.quest.completed and not self.teleport_ready:
+            self.activate_teleport()
+
+    def draw_world(self) -> None:
+        if not self.world or not self.player:
+            return
+        self.canvas.fill(settings.COLOR_BLACK)
+        for tile in self.world.iter_tiles():
+            pygame.draw.rect(self.canvas, tile.color, tile.rect)
+
+        for pickup in self.pickups:
+            pickup.draw(self.canvas)
+        for enemy in self.enemies:
+            enemy.draw(self.canvas)
+        for projectile in self.projectiles:
+            projectile.draw(self.canvas)
+        self.player.draw(self.canvas)
+
+        draw_hud(self.canvas, self)
+
+    def draw_menu(self) -> None:
+        self.canvas.fill((12, 12, 18))
+        title = self.font_large.render("First Game in Python", True, settings.COLOR_WHITE)
+        prompt = self.font_small.render("Pressione Enter para iniciar", True, (200, 200, 200))
+        difficulty = self.font_small.render(f"Dificuldade: {self.difficulty.name.title()}", True, (180, 200, 255))
+        self.canvas.blit(title, (40, 60))
+        self.canvas.blit(prompt, (40, 120))
+        self.canvas.blit(difficulty, (40, 160))
+
+    def draw_game_over(self) -> None:
+        self.canvas.fill((30, 0, 0))
+        title = self.font_large.render("Game Over", True, (255, 120, 120))
+        prompt = self.font_small.render("Pressione Enter para tentar novamente", True, settings.COLOR_WHITE)
+        score = self.font_small.render(f"Pontuação final: {int(self.score)}", True, settings.COLOR_WHITE)
+        self.canvas.blit(title, (80, 60))
+        self.canvas.blit(prompt, (20, 120))
+        self.canvas.blit(score, (20, 160))
+
+    def draw(self) -> None:
+        if self.state == settings.GameState.MENU:
+            self.draw_menu()
+        elif self.state == settings.GameState.PLAYING:
+            self.draw_world()
+        elif self.state == settings.GameState.GAME_OVER:
+            self.draw_game_over()
+        scaled = pygame.transform.scale(self.canvas, (settings.DISPLAY_WIDTH, settings.DISPLAY_HEIGHT))
+        self.screen.blit(scaled, (0, 0))
+        pygame.display.flip()
+
+    def update(self, dt: float) -> None:
+        if self.state == settings.GameState.PLAYING:
+            self.update_gameplay(dt)
+        elif self.state == settings.GameState.GAME_OVER:
+            self.update_messages(dt)
+
+    def handle_event(self, event: pygame.event.Event) -> None:
+        if self.state == settings.GameState.MENU:
+            self.handle_menu_event(event)
+        elif self.state == settings.GameState.PLAYING:
+            self.handle_playing_event(event)
+        elif self.state == settings.GameState.GAME_OVER:
+            if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
+                self.start_game()
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE:
+                self.reset_to_menu()
+
+    def run(self) -> None:
+        running = True
+        while running:
+            dt = self.clock.tick(settings.FPS) / 1000.0
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                else:
+                    self.handle_event(event)
+            self.update(dt)
+            self.draw()
+        pygame.quit()

--- a/python_port/python_port/main.py
+++ b/python_port/python_port/main.py
@@ -1,0 +1,26 @@
+"""Ponto de entrada do jogo em Python."""
+from __future__ import annotations
+
+import argparse
+
+from . import settings
+from .game import Game
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="First Game in Python")
+    parser.add_argument("--difficulty", choices=[d.name.lower() for d in settings.Difficulty], default=settings.Difficulty.NORMAL.name.lower(), help="Define a dificuldade inicial")
+    parser.add_argument("--level", type=int, default=1, help="Mapa inicial (ex.: 1 gera level1.png)")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    difficulty = next(d for d in settings.Difficulty if d.name.lower() == args.difficulty)
+    game = Game(difficulty=difficulty, start_level=args.level)
+    game.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/python_port/python_port/settings.py
+++ b/python_port/python_port/settings.py
@@ -1,0 +1,83 @@
+"""Configurações globais utilizadas pela porta em Python."""
+from __future__ import annotations
+
+from pathlib import Path
+
+# A janela do pygame utiliza o mesmo tamanho interno da versão Java (384x216),
+# ampliado por um fator de escala.
+INTERNAL_WIDTH = 384
+INTERNAL_HEIGHT = 216
+SCALE = 3
+DISPLAY_WIDTH = INTERNAL_WIDTH * SCALE
+DISPLAY_HEIGHT = INTERNAL_HEIGHT * SCALE
+FPS = 60
+
+TILE_SIZE = 16
+
+# Caminho base para localizar recursos reutilizados do projeto Java.
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RESOURCES_PATH = PROJECT_ROOT / "res"
+MAP_PATTERN = "level{level}.png"
+
+# A lógica de combo utiliza janelas temporais em segundos.
+COMBO_TIMEOUT = 4.0
+COMBO_INCREMENT = 1
+
+# Estados do jogo.
+from enum import Enum, auto
+
+
+class GameState(Enum):
+    MENU = auto()
+    PLAYING = auto()
+    GAME_OVER = auto()
+
+
+class Difficulty(Enum):
+    EASY = "easy"
+    NORMAL = "normal"
+    HARD = "hard"
+
+    @property
+    def damage_multiplier(self) -> float:
+        return {
+            Difficulty.EASY: 0.75,
+            Difficulty.NORMAL: 1.0,
+            Difficulty.HARD: 1.35,
+        }[self]
+
+    @property
+    def enemy_spawn_multiplier(self) -> float:
+        return {
+            Difficulty.EASY: 0.85,
+            Difficulty.NORMAL: 1.0,
+            Difficulty.HARD: 1.2,
+        }[self]
+
+    @property
+    def player_stats(self) -> dict[str, float]:
+        """Retorna ajustes aplicados ao jogador na inicialização."""
+        base = {
+            "max_health": 120,
+            "max_shield": 80,
+            "max_energy": 100,
+            "max_ammo": 120,
+        }
+        if self is Difficulty.EASY:
+            return {k: v * 1.2 for k, v in base.items()}
+        if self is Difficulty.HARD:
+            return {k: v * 0.85 for k, v in base.items()}
+        return base
+
+
+# Paleta utilizada para gerar superfícies coloridas rapidamente.
+COLOR_BLACK = (0, 0, 0)
+COLOR_WHITE = (255, 255, 255)
+COLOR_FLOOR = (30, 30, 30)
+COLOR_WALL = (180, 180, 180)
+COLOR_PLAYER = (0, 150, 255)
+COLOR_ENEMY = (255, 64, 64)
+COLOR_PICKUP = (255, 215, 0)
+COLOR_SHIELD = (142, 36, 170)
+COLOR_ENERGY = (29, 233, 182)
+

--- a/python_port/python_port/ui.py
+++ b/python_port/python_port/ui.py
@@ -1,0 +1,63 @@
+"""Rotinas de desenho da HUD."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pygame
+
+from . import settings
+
+if TYPE_CHECKING:
+    from .game import Game
+
+
+@dataclass
+class FloatingMessage:
+    text: str
+    position: pygame.Vector2
+    timer: float = 0.0
+    duration: float = 1.2
+
+    def update(self, dt: float) -> None:
+        self.timer += dt
+        self.position.y -= 12 * dt
+
+    @property
+    def alive(self) -> bool:
+        return self.timer < self.duration
+
+
+def draw_meter(surface: pygame.Surface, label: str, value: float, maximum: float, position: tuple[int, int], size: tuple[int, int], color: tuple[int, int, int]) -> None:
+    x, y = position
+    width, height = size
+    pygame.draw.rect(surface, (20, 20, 20), (x, y, width, height))
+    if maximum > 0:
+        fill_width = int((value / maximum) * width)
+        pygame.draw.rect(surface, color, (x, y, fill_width, height))
+    font = pygame.font.Font(None, 18)
+    label_surface = font.render(f"{label}: {int(value)}/{int(maximum)}", True, settings.COLOR_WHITE)
+    surface.blit(label_surface, (x + 4, y + 2))
+
+
+def draw_hud(surface: pygame.Surface, game: "Game") -> None:
+    player = game.player
+    draw_meter(surface, "Vida", player.health, player.max_health, (8, 8), (120, 16), (220, 68, 68))
+    draw_meter(surface, "Escudo", player.shield, player.max_shield, (8, 30), (120, 16), settings.COLOR_SHIELD)
+    draw_meter(surface, "Energia", player.energy, player.max_energy, (8, 52), (120, 16), (64, 196, 255))
+    draw_meter(surface, "Munição", player.ammo, player.max_ammo, (8, 74), (120, 16), (255, 214, 102))
+
+    font = pygame.font.Font(None, 24)
+    score_surface = font.render(f"Pontuação: {int(game.score)}", True, settings.COLOR_WHITE)
+    combo_surface = font.render(f"Combo x{game.combo_multiplier}", True, (255, 200, 80))
+    quest_surface = font.render(game.quest_status, True, (140, 200, 255))
+
+    surface.blit(score_surface, (settings.INTERNAL_WIDTH - 180, 8))
+    surface.blit(combo_surface, (settings.INTERNAL_WIDTH - 180, 32))
+    surface.blit(quest_surface, (settings.INTERNAL_WIDTH - 220, settings.INTERNAL_HEIGHT - 28))
+
+    for message in game.messages:
+        alpha = max(0, 255 * (1 - message.timer / message.duration))
+        message_surface = font.render(message.text, True, (255, 255, 255))
+        message_surface.set_alpha(alpha)
+        surface.blit(message_surface, (int(message.position.x), int(message.position.y)))

--- a/python_port/python_port/world.py
+++ b/python_port/python_port/world.py
@@ -1,0 +1,146 @@
+"""Carregamento de mapas e gerenciamento de tiles."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterator, List, Sequence
+
+from PIL import Image
+
+from . import settings
+
+
+@dataclass(frozen=True)
+class Tile:
+    x: int
+    y: int
+    walkable: bool
+    color: tuple[int, int, int]
+
+    @property
+    def rect(self) -> tuple[int, int, int, int]:
+        return (
+            self.x * settings.TILE_SIZE,
+            self.y * settings.TILE_SIZE,
+            settings.TILE_SIZE,
+            settings.TILE_SIZE,
+        )
+
+
+@dataclass(frozen=True)
+class SpawnInstruction:
+    kind: str
+    position: tuple[int, int]
+    variant: str | None = None
+
+
+class World:
+    """Representa o mapa carregado a partir de um arquivo PNG."""
+
+    def __init__(self, width: int, height: int, tiles: Sequence[Tile], spawns: List[SpawnInstruction], player_spawn: tuple[int, int]):
+        self.width = width
+        self.height = height
+        self.tiles = list(tiles)
+        self._grid: Dict[tuple[int, int], Tile] = {(tile.x, tile.y): tile for tile in self.tiles}
+        self.spawns = spawns
+        self.player_spawn = player_spawn
+
+    @classmethod
+    def from_level(cls, level: int, *, resources_path: Path | None = None) -> "World":
+        resources = resources_path or settings.RESOURCES_PATH
+        image_path = resources / settings.MAP_PATTERN.format(level=level)
+        if not image_path.exists():
+            raise FileNotFoundError(f"Mapa não encontrado: {image_path}")
+
+        image = Image.open(image_path).convert("RGBA")
+        width, height = image.size
+        pixels = image.load()
+
+        tiles: List[Tile] = []
+        spawns: List[SpawnInstruction] = []
+        player_spawn = (0, 0)
+
+        def spawn(kind: str, x: int, y: int, variant: str | None = None) -> None:
+            spawns.append(SpawnInstruction(kind, (x * settings.TILE_SIZE, y * settings.TILE_SIZE), variant))
+
+        for y in range(height):
+            for x in range(width):
+                r, g, b, a = pixels[x, y]
+                walkable = True
+                tile_color = settings.COLOR_FLOOR
+
+                color_value = (r << 16) + (g << 8) + b
+
+                if color_value == 0xFFFFFFFF:
+                    walkable = False
+                    tile_color = settings.COLOR_WALL
+                elif color_value == 0xFF808080:
+                    walkable = False
+                    tile_color = (110, 110, 110)
+                elif color_value == 0xFF0026FF:
+                    player_spawn = (x * settings.TILE_SIZE, y * settings.TILE_SIZE)
+                elif color_value in ENEMY_COLOR_TABLE:
+                    walkable = True
+                    spawn("enemy", x, y, ENEMY_COLOR_TABLE[color_value])
+                elif color_value == 0xFFFF6A00:
+                    spawn("weapon", x, y)
+                elif color_value == 0xFF4CFF00:
+                    spawn("lifepack", x, y)
+                elif color_value == 0xFFFFD800:
+                    spawn("ammo", x, y)
+                elif color_value == 0xFF8E24AA:
+                    spawn("shield", x, y)
+                elif color_value == 0xFF1DE9B6:
+                    spawn("energy", x, y)
+                elif color_value == 0xFFFF5252:
+                    spawn("nanomedkit", x, y)
+                elif color_value == 0xFF00E5FF:
+                    spawn("overclock", x, y)
+                elif color_value == 0xFFFFC107:
+                    spawn("quest_item", x, y)
+                elif color_value == 0xFF00ACC1:
+                    spawn("data_core", x, y)
+                elif color_value == 0xFF4CAF50:
+                    spawn("quest_beacon", x, y)
+                elif color_value == 0xFF795548:
+                    spawn("quest_npc", x, y)
+                elif color_value == 0xFFFFB74D:
+                    spawn("engineer", x, y)
+                elif color_value == 0xFF7E57C2:
+                    spawn("researcher", x, y)
+                elif color_value == 0xFF673AB7:
+                    spawn("teleport_pad", x, y)
+
+                tiles.append(Tile(x, y, walkable, tile_color))
+
+        image.close()
+        return cls(width, height, tiles, spawns, player_spawn)
+
+    def is_walkable(self, pixel_x: int, pixel_y: int) -> bool:
+        tile_x = pixel_x // settings.TILE_SIZE
+        tile_y = pixel_y // settings.TILE_SIZE
+        tile = self._grid.get((tile_x, tile_y))
+        return tile.walkable if tile else False
+
+    def rect_collides(self, rect: tuple[int, int, int, int]) -> bool:
+        x, y, w, h = rect
+        for sample_x in (x, x + w - 1):
+            for sample_y in (y, y + h - 1):
+                if not self.is_walkable(sample_x, sample_y):
+                    return True
+        return False
+
+    def iter_tiles(self) -> Iterator[Tile]:
+        return iter(self.tiles)
+
+
+ENEMY_COLOR_TABLE: Dict[int, str] = {
+    0xFFFF0000: "scout",
+    0xFF9C27B0: "teleporter",
+    0xFF00BCD4: "artillery",
+    0xFF3F51B5: "warden",
+    0xFF009688: "sentinel",
+    0xFFF4511E: "ravager",
+    0xFFE91E63: "warbringer",
+    0xFF7986CB: "overseer",
+}


### PR DESCRIPTION
## Summary
- add a new `python_port` package that recreates the core gameplay loop, entities, combat and quest systems with pygame
- load existing PNG levels to spawn enemies and pickups while rendering a HUD and floating messages in the Python build
- document installation and execution steps for the Python port and declare its dependencies via `pyproject.toml`

## Testing
- python -m compileall python_port/python_port

------
https://chatgpt.com/codex/tasks/task_e_68f6ae8a2f9883319886b62ebe65cf15