### PR TITLE
Rodada 21 — Transição de fase calmante + polimento

### DIFF
--- a/src/com/traduvertgames/graficos/MissionBanner.java
+++ b/src/com/traduvertgames/graficos/MissionBanner.java
@@ -24,6 +24,15 @@ public final class MissionBanner {
 	private static int life = 0;
 	private static boolean announced = false;
 
+	/**
+	 * Lore da próxima fase agendada (rodada 21): o banner de ambientação não
+	 * compete mais com o aviso de conclusão nem com o card de estatísticas —
+	 * aparece apenas após o jogador fechar o card e o fade revelar a nova fase.
+	 */
+	private static String scheduledTitle = "";
+	private static String scheduledSubtitle = "";
+	private static int scheduledDelay = 0;
+
 	private MissionBanner() {
 	}
 
@@ -56,6 +65,9 @@ public final class MissionBanner {
 		announced = false;
 		title = "";
 		subtitle = "";
+		scheduledTitle = "";
+		scheduledSubtitle = "";
+		scheduledDelay = 0;
 	}
 
 	/** Desmarca a flag de anúncio sem esconder o banner visível. */
@@ -67,10 +79,32 @@ public final class MissionBanner {
 		return life > 0;
 	}
 
-	/** Atualiza o tempo de vida do banner. */
+	/**
+	 * Agenda o banner de lore da próxima fase para aparecer daqui a
+	 * `delayFrames` — usado na transição de fase: a lore só entra depois
+	 * que o cooldown de respiro (rodada 21) termina.
+	 */
+	public static void scheduleLore(String title, String subtitle, int delayFrames) {
+		scheduledTitle = title;
+		scheduledSubtitle = subtitle;
+		scheduledDelay = delayFrames;
+	}
+
+	/** Atualiza o tempo de vida do banner e dispara a lore agendada. */
 	public static void update() {
 		if (life > 0) {
 			life--;
+		}
+		// Rodada 21: quando o cooldown da transição termina, exibe a lore
+		// da nova fase (se houver agendamento pendente).
+		if (scheduledDelay > 0) {
+			scheduledDelay--;
+			if (scheduledDelay == 0 && !scheduledTitle.isEmpty()) {
+				show(scheduledTitle, scheduledSubtitle,
+					new Color(255, 235, 59), Color.WHITE, 300);
+				scheduledTitle = "";
+				scheduledSubtitle = "";
+			}
 		}
 	}
 

--- a/src/com/traduvertgames/graficos/PhaseStatsScreen.java
+++ b/src/com/traduvertgames/graficos/PhaseStatsScreen.java
@@ -53,7 +53,13 @@ public final class PhaseStatsScreen {
 		return showing;
 	}
 
-	/** Fecha o card liberando o jogo (Enter ou tempo esgotado). */
+	/**
+	 * Fecha o card liberando o jogo (Enter). Na campanha, o jogo não retoma
+	 * o combate de imediato: entra no cooldown de respiro pós-transição
+	 * (rodada 21) — inimigos ficam congelados por ~2,5s para o jogador se
+	 * orientar. No modo sobrevivência (infinito), o auto-dismiss é mantido
+	 * para não travar o fluxo de ondas.
+	 */
 	public static void dismiss() {
 		if (!showing) {
 			return;
@@ -61,6 +67,9 @@ public final class PhaseStatsScreen {
 		showing = false;
 		Menu.pause = false;
 		Game.gameState = "NORMAL";
+		if (!com.traduvertgames.main.WaveManager.isArenaMode()) {
+			Game.startTransitionCooldown();
+		}
 	}
 
 	/** Enter fecha o card; ESC cancela para o menu principal (comportamento de fallback). */
@@ -80,7 +89,11 @@ public final class PhaseStatsScreen {
 			}
 		} else if (enter && framesElapsed > FADE_TOTAL) {
 			dismiss();
-		} else if (framesElapsed > AUTO_DISMISS_FRAMES) {
+		// Rodada 21: na campanha o card não fecha sozinho — o jogador deve
+		// apertar Enter. No modo sobrevivência o auto-dismiss continua
+		// existindo para manter o fluxo de ondas.
+		} else if (com.traduvertgames.main.WaveManager.isArenaMode()
+				&& framesElapsed > AUTO_DISMISS_FRAMES) {
 			dismiss();
 		}
 	}

--- a/src/com/traduvertgames/main/Game.java
+++ b/src/com/traduvertgames/main/Game.java
@@ -157,8 +157,24 @@ public class Game extends Canvas implements Runnable, KeyListener, MouseListener
          * somar esses valores às próprias coordenadas. */
         public static int drawOffsetX = 0;
         public static int drawOffsetY = 0;
-        /** Frames restantes de exibição do aviso "Fase X concluída — próxima fase". */
+	/** Frames restantes de exibição do aviso "Fase X concluída — próxima fase". */
         private static int showLevelTransition = 0;
+        /** Cooldown de respiro pós-transição (rodada 21): enquanto > 0, inimigos
+         * ficam congelados e o WaveManager não spawna, dando ao jogador ~2,5s
+         * para se orientar na nova fase. O aviso de transição também fica
+         * fixo durante o cooldown (não decresce). */
+        private static final int RESPIRO_FRAMES = 150;
+        private static int transitionCooldown = 0;
+
+        /** Inicia o cooldown de respiro após a tela de estatísticas fechar. */
+        public static void startTransitionCooldown() {
+                transitionCooldown = RESPIRO_FRAMES;
+        }
+
+        /** True enquanto o cooldown pós-transição estiver ativo. */
+        public static boolean isTransitionCooldown() {
+                return transitionCooldown > 0;
+        }
         /** Opacidade do fade preto da transição de fase (150 = totalmente escuro). */
         private static int transitionAlpha = 0;
 
@@ -541,20 +557,38 @@ public class Game extends Canvas implements Runnable, KeyListener, MouseListener
 
                         DashAbility.update();
                         UltimateAbility.update();
-                        WaveManager.update();
+                        // Respiro pós-transição (rodada 21): durante o cooldown o
+                        // WaveManager não spawna novos lotes — a próxima fase abre
+                        // calma, sem mobs surgindo de imediato.
+                        if (!isTransitionCooldown()) {
+                                WaveManager.update();
+                        }
                         LevelUpManager.update();
                         LootGuarantee.update();
 
-			for (int i = 0; i < entities.size(); i++) {
-				Entity e = entities.get(i);
-				// Durante o onboarding, inimigos ficam paralisados para o novato
-				// praticar sem risco (Player continua atualizando normalmente).
-if (e instanceof Enemy && (OnboardingManager.isEnemyPaused() || DialogueManager.isEnemyPaused())) {
+				for (int i = 0; i < entities.size(); i++) {
+					Entity e = entities.get(i);
+					// Durante o onboarding, inimigos ficam paralisados para o novato
+					// praticar sem risco (Player continua atualizando normalmente).
+					// Cooldown pós-transição (rodada 21): inimigos também ficam
+					// congelados até o jogador se orientar na nova fase.
+if (e instanceof Enemy && (OnboardingManager.isEnemyPaused() || DialogueManager.isEnemyPaused() || isTransitionCooldown())) {
 						continue;
 					}
-				e.update();
-			}
-			OnboardingManager.update();
+					e.update();
+				}
+				OnboardingManager.update();
+
+				// Cooldown de respiro: decai apenas durante o estado NORMAL (a
+				// contagem não corre enquanto a tela de estatísticas estiver aberta).
+				if (transitionCooldown > 0) {
+					transitionCooldown--;
+					if (transitionCooldown == 0) {
+						// Inimigos voltam a agir; projéteis antigos já foram
+						// removidos na conclusão da fase anterior.
+						showLevelTransition = 0;
+					}
+				}
 
                         for (int i = 0; i < bullets.size(); i++) {
                                 bullets.get(i).update();
@@ -618,12 +652,15 @@ if (e instanceof Enemy && (OnboardingManager.isEnemyPaused() || DialogueManager.
 			LevelSelectScreen.update();
 	}
 
-		if (showLevelTransition > 0) {
+		// showLevelTransition decai apenas fora do cooldown pós-transição
+		// (rodada 21): o aviso de transição permanece na tela até o fim do
+		// respiro, evitando que a mensagem suma com o jogo já em combate.
+		if (showLevelTransition > 0 && transitionCooldown <= 0) {
 			showLevelTransition--;
 		}
-		// Fade preto da transição de fase: escurece a fase antiga e some
-		// suavemente para revelar a nova (fade de ~50 frames).
-		if (transitionAlpha > 0) {
+		// Fade preto da transição não decai durante o cooldown: a nova fase
+		// só é revelada quando o jogador está pronto.
+		if (transitionAlpha > 0 && transitionCooldown <= 0) {
 			transitionAlpha = Math.max(0, transitionAlpha - 3);
 		}
 	}
@@ -674,15 +711,17 @@ if (e instanceof Enemy && (OnboardingManager.isEnemyPaused() || DialogueManager.
 
 // Renderizar jogo //
 		world.render(g);
-		// Fase concluída: inimigos e seus projéteis ficam invisíveis — a
-		// próxima fase carrega limpa, sem "ruído" herdado da anterior.
-		for (int i = 0; i < entities.size(); i++) {
-			Entity e = entities.get(i);
-			if (questCompletedPending && e instanceof Enemy) {
-				continue;
+			// Fase concluída: inimigos e seus projéteis ficam invisíveis — a
+			// próxima fase carrega limpa, sem "ruído" herdado da anterior.
+			// Cooldown pós-transição (rodada 21): inimigos também permanecem
+			// invisíveis durante o respiro inicial da nova fase.
+			for (int i = 0; i < entities.size(); i++) {
+				Entity e = entities.get(i);
+				if ((questCompletedPending || isTransitionCooldown()) && e instanceof Enemy) {
+					continue;
+				}
+				e.render(g);
 			}
-			e.render(g);
-		}
 		for (int i = 0; i < bullets.size(); i++) {
 			bullets.get(i).render(g);
 		}
@@ -760,7 +799,9 @@ if (e instanceof Enemy && (OnboardingManager.isEnemyPaused() || DialogueManager.
 				java.awt.RenderingHints.VALUE_FRACTIONALMETRICS_ON);
 		// Durante a transição de fase (banner de conclusão / lore) as HUDs
 		// de combate ficam escondidas para deixar o momento mais limpo.
-		boolean hidingHud = questCompletedPending || showLevelTransition > 0;
+		// Rodada 21: o card de estatísticas também conta como transição.
+		boolean hidingHud = questCompletedPending || showLevelTransition > 0
+				|| com.traduvertgames.graficos.PhaseStatsScreen.isShowing();
 if (!hidingHud) {
 	MiniMap.render(overlayG);
 	// Texto do banner central renderizado no overlay (espaço escalado): letras
@@ -833,13 +874,17 @@ if (!hidingHud) {
                         drawCenteredString(overlayG, "Recorde: " + Game.getHighScore(), scaledHeight / 2 + 82);
                         drawCenteredString(overlayG, "Melhor combo da partida: x" + Game.getBestComboThisRun(), scaledHeight / 2 + 112);
 
-                } else if ("MENU".equals(gameState)) {
-                        if (!showInitialWeaponSelect) {
-			menu.render(overlayG);
-                        }
-                        // Durante a seleção de arma inicial o menu não deve
-                        // desenhar nada: o overlay da própria tela de arma
-                        // escurece o fundo e desenha a lista por cima.
+                		} else if ("MENU".equals(gameState)) {
+				// Rodada 21: durante a transição de fase (card de estatísticas
+				// ou aviso de conclusão) o menu principal não é desenhado —
+				// antes ele aparecia por trás do aviso, com textos sobrepostos.
+				if (!showInitialWeaponSelect && showLevelTransition <= 0
+						&& !com.traduvertgames.graficos.PhaseStatsScreen.isShowing()) {
+					menu.render(overlayG);
+				}
+				// Durante a seleção de arma inicial o menu não deve
+				// desenhar nada: o overlay da própria tela de arma
+				// escurece o fundo e desenha a lista por cima.
 		} else if ("SHOP".equals(gameState)) {
 				// Painel único da loja (fundo escuro + lista + feedback + dica).
 				// Sem Menu.renderPauseScreen atrás: o overlay do menu de pausa
@@ -1520,7 +1565,10 @@ if (!hidingHud) {
 				LevelUpManager.dismiss();
 			}
 			applyProgressBonuses();
-			showLevelTransition = 180;
+			// Cooldown de respiro (rodada 21) mesmo na entrada do modo
+			// sobrevivência: inimigos não atacam de imediato.
+			transitionCooldown = RESPIRO_FRAMES;
+			showLevelTransition = 180 + RESPIRO_FRAMES;
 		transitionAlpha = 150;
 			return;
 		}
@@ -1541,17 +1589,22 @@ if (!hidingHud) {
 		String newWorld = "level" + CUR_LEVEL + ".png";
 		World.restartGame(newWorld);
 		// Card de estatísticas da fase que acabou de terminar (kills, tempo, combo).
+		// Rodada 21: o card fica pausado na frente do jogo e só fecha por Enter
+		// (sem auto-dismiss na campanha) — a tela não é arremessada ao combate.
 		com.traduvertgames.graficos.PhaseStatsScreen.show();
 		// Transição de fase limpa: fade preto suave para "apagar" a fase
 		// antiga antes de revelar a nova, com HUDs escondidas no meio tempo.
+		// O fade decai apenas quando o cooldown pós-transição terminar.
 		transitionAlpha = 150;
-		showLevelTransition = 150;
+		showLevelTransition = 150 + RESPIRO_FRAMES;
 		// Lore da nova fase: título e texto de ambientação em destaque dourado.
+		// Rodada 21: o banner de lore é adiado para o fim do respiro — antes
+		// ele competia com o card de estatísticas e com o aviso de conclusão.
 		com.traduvertgames.graficos.MissionBanner.reset();
-		com.traduvertgames.graficos.MissionBanner.show(
+		com.traduvertgames.graficos.MissionBanner.scheduleLore(
 			com.traduvertgames.quest.StoryManager.getPhaseLoreTitle(CUR_LEVEL),
 			com.traduvertgames.quest.StoryManager.getPhaseLore(CUR_LEVEL),
-			new Color(255, 235, 59), Color.WHITE, 360);
+			RESPIRO_FRAMES);
 	}
 
 	/**
@@ -1561,8 +1614,9 @@ if (!hidingHud) {
 	public static void enterSurvivalMode() {
 		QuestManager.prepareForLevel(MAX_LEVEL + 1);
 		WaveManager.startArena();
-		showLevelTransition = 180;
+		showLevelTransition = 180 + RESPIRO_FRAMES;
 		transitionAlpha = 150;
+		transitionCooldown = RESPIRO_FRAMES;
 		// Card de estatísticas do ciclo anterior do modo infinito (se não for a
 		// primeira entrada, que já ganha a cutscene de vitória da campanha).
 		if (instance != null && instance.levelPlus > 1) {
@@ -1581,7 +1635,9 @@ if (!hidingHud) {
 		}
 		QuestManager.prepareForLevel(MAX_LEVEL + 1);
 		startProceduralLevel(1);
-		showLevelTransition = 180;
+		// Cooldown de respiro (rodada 21): inimigos não atacam de imediato.
+		transitionCooldown = RESPIRO_FRAMES;
+		showLevelTransition = 180 + RESPIRO_FRAMES;
 		transitionAlpha = 150;
 	}
 
@@ -1600,9 +1656,12 @@ if (!hidingHud) {
 		QuestManager.prepareForLevel(MAX_LEVEL + 1);
 		applyProgressBonuses();
 		// Card de estatísticas do ciclo que acabou de terminar.
+		// Rodada 21: no modo infinito o card fecha sozinho (auto-dismiss), e o
+		// cooldown de respiro impede que os mobs ataquem de imediato.
 		com.traduvertgames.graficos.PhaseStatsScreen.show();
 		startProceduralLevel(depth);
-		showLevelTransition = 180;
+		transitionCooldown = RESPIRO_FRAMES;
+		showLevelTransition = 180 + RESPIRO_FRAMES;
 		transitionAlpha = 150;
 	}
 

--- a/tools/PhaseTransitionTest.java
+++ b/tools/PhaseTransitionTest.java
@@ -84,14 +84,16 @@ public class PhaseTransitionTest {
         check("QuestManager acompanhou a fase 2",
             com.traduvertgames.quest.QuestManager.getCurrentLevel() == 2);
 
-        Field fLife = com.traduvertgames.graficos.MissionBanner.class.getDeclaredField("life");
-        fLife.setAccessible(true);
-        int life = (int) fLife.get(null);
-        check("banner de lore ativo na fase 2", life > 0);
-        Field fSub = com.traduvertgames.graficos.MissionBanner.class.getDeclaredField("subtitle");
-        fSub.setAccessible(true);
-        String sub = (String) fSub.get(null);
-        check("lore da fase 2 exibida", sub != null && !sub.isEmpty());
+	// Rodada 21: a lore é agendada (scheduleLore) e só aparece depois do
+	// cooldown pós-transição — verificar os campos de agendamento.
+	Field fDelay = com.traduvertgames.graficos.MissionBanner.class.getDeclaredField("scheduledDelay");
+	fDelay.setAccessible(true);
+	int delay = (int) fDelay.get(null);
+	check("lore da fase 2 agendada (delay > 0)", delay > 0);
+	Field fSub = com.traduvertgames.graficos.MissionBanner.class.getDeclaredField("scheduledSubtitle");
+	fSub.setAccessible(true);
+	String sub = (String) fSub.get(null);
+	check("lore da fase 2 registrada para exibição", sub != null && !sub.isEmpty());
 
         // 6) NPCs temáticos na fase 2 fora do canto de spawn
         int storyNpcsAway = 0;

--- a/tools/TransitionCooldownTest.java
+++ b/tools/TransitionCooldownTest.java
@@ -1,0 +1,152 @@
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import com.traduvertgames.entities.Enemy;
+import com.traduvertgames.graficos.PhaseStatsScreen;
+import com.traduvertgames.graficos.MissionBanner;
+import com.traduvertgames.main.Game;
+import com.traduvertgames.main.SoundManager;
+import com.traduvertgames.main.WaveManager;
+
+/**
+ * Rodada 21 — testa o cooldown de respiro pós-transição:
+ * 1. advanceToNextLevel() arma transitionCooldown = RESPIRO_FRAMES
+ * 2. Durante o cooldown: aviso fixo (showLevelTransition não decai),
+ *    fade fixo (transitionAlpha não decai), WaveManager não spawna,
+ *    inimigos congelados
+ * 3. Ao final do cooldown: tudo zera e o combate retoma
+ * 4. PhaseStatsScreen na campanha não fecha sozinho (sem auto-dismiss)
+ * 5. Banner de lore da nova fase é agendado (scheduleLore) e só dispara
+ *    quando o cooldown termina
+ */
+public class TransitionCooldownTest {
+	static int fails = 0;
+
+	static void check(String name, boolean ok) {
+		System.out.println((ok ? "[PASS] " : "[FAIL] ") + name);
+		if (!ok) {
+			fails++;
+		}
+	}
+
+	static int getInt(Class<?> clazz, String field) throws Exception {
+		Field f = clazz.getDeclaredField(field);
+		f.setAccessible(true);
+		return f.getInt(null);
+	}
+
+	static void setInt(Class<?> clazz, String field, int value) throws Exception {
+		Field f = clazz.getDeclaredField(field);
+		f.setAccessible(true);
+		f.setInt(null, value);
+	}
+
+	public static void main(String[] args) throws Exception {
+		// Desativar áudio: remover pools de clips para não travar sem dispositivo
+		SoundManager.unload();
+		Game g = new Game();
+		g.setCurrentLevel(2);
+		com.traduvertgames.world.World.restartGame("level2.png");
+		com.traduvertgames.quest.QuestManager.onLevelLoaded();
+		Game.gameState = "NORMAL";
+
+		// --- 1. Cooldown é armado ao avançar de fase ---
+		System.out.println("[Teste 1] Cooldown armado em advanceToNextLevel");
+		setInt(Game.class, "transitionCooldown", 0);
+		setInt(Game.class, "showLevelTransition", 0);
+		setInt(Game.class, "transitionAlpha", 0);
+		Game.advanceToNextLevel();
+		// Após o avanço o estado é MENU (card de estatísticas na frente);
+		// o cooldown decairá quando o jogador fechar o card (Enter/dismiss).
+
+		int cooldown = getInt(Game.class, "transitionCooldown");
+		check("estado é MENU com o card de estatísticas na frente",
+				"MENU".equals(Game.gameState));
+		check("aviso prolongado (>= RESPIRO)", getInt(Game.class, "showLevelTransition") >= 150);
+		check("fade ativo (150)", getInt(Game.class, "transitionAlpha") == 150);
+		System.out.println("    cooldown=" + cooldown);
+		// Simula o fechamento do card pelo jogador (Enter): disparará o
+		// cooldown de respiro.
+		PhaseStatsScreen.dismiss();
+		cooldown = getInt(Game.class, "transitionCooldown");
+		check("cooldown > 0 após fechar o card", cooldown > 0);
+		System.out.println("    cooldown após dismiss=" + cooldown);
+
+		// --- 2. Aviso e fade fixos durante o cooldown ---
+		System.out.println("[Teste 2] Aviso e fade fixos durante o cooldown");
+		int trBefore = getInt(Game.class, "showLevelTransition");
+		int alphaBefore = getInt(Game.class, "transitionAlpha");
+		g.update();
+		g.update();
+		check("showLevelTransition não decai durante cooldown",
+				getInt(Game.class, "showLevelTransition") == trBefore);
+		check("transitionAlpha não decai durante cooldown",
+				getInt(Game.class, "transitionAlpha") == alphaBefore);
+
+		// --- 3. Cooldown decai no estado NORMAL ---
+		System.out.println("[Teste 3] Cooldown decai e libera o combate");
+		Game.gameState = "NORMAL";
+		int cd = getInt(Game.class, "transitionCooldown");
+		for (int i = 0; i <= cd + 5; i++) {
+			g.update();
+		}
+		check("cooldown zera ao final", getInt(Game.class, "transitionCooldown") == 0);
+		check("showLevelTransition zera ao final",
+				getInt(Game.class, "showLevelTransition") == 0);
+		int alphaFinal = getInt(Game.class, "transitionAlpha");
+		check("fade esmaeceu ao final", alphaFinal < alphaBefore);
+		// O fade decai junto com o cooldown: no último frame ele ainda
+		// pode estar ligeiramente acima de 0 (o jogo revela a fase).
+
+		// --- 4. Card de stats na campanha não fecha sozinho ---
+		System.out.println("[Teste 4] Card de stats na campanha só fecha por Enter");
+		WaveManager.stopArena();
+		Game.advanceToNextLevel();
+		PhaseStatsScreen.show();
+		check("card visível", PhaseStatsScreen.isShowing());
+		for (int i = 0; i < 300; i++) {
+			PhaseStatsScreen.update(false, false);
+		}
+		check("card permanece visível após 300 frames (sem auto-dismiss na campanha)",
+				PhaseStatsScreen.isShowing());
+		// No modo infinito (arena ativa), o auto-dismiss continua funcionando:
+		WaveManager.startArena();
+		PhaseStatsScreen.show();
+		for (int i = 0; i < 320; i++) {
+			PhaseStatsScreen.update(false, false);
+		}
+		check("auto-dismiss mantém funcionando no modo infinito",
+				!PhaseStatsScreen.isShowing());
+
+		// --- 5. Inimigos congelados durante o cooldown ---
+		System.out.println("[Teste 5] Inimigos congelados durante o cooldown");
+		WaveManager.stopArena();
+		Game.advanceToNextLevel();
+		PhaseStatsScreen.dismiss(); // fecha o card → inicia o cooldown
+		Game.gameState = "NORMAL";
+		Enemy spy = new Enemy(10, 10, 16, 16, null);
+		Game.enemies.add(spy);
+		double xBefore = spy.getX();
+		g.update();
+		g.update();
+		check("inimigo não se move durante cooldown", Math.abs(spy.getX() - xBefore) < 0.001);
+		Game.enemies.remove(spy);
+
+		// --- 6. Banner de lore agendado dispara ao fim do cooldown ---
+		System.out.println("[Teste 6] Lore agendada dispara ao fim do cooldown");
+		WaveManager.stopArena();
+		Game.advanceToNextLevel();
+		PhaseStatsScreen.dismiss(); // fecha o card → inicia o cooldown
+		Game.gameState = "NORMAL";
+		check("banner de lore agendado (não exibido de imediato)",
+				getInt(MissionBanner.class, "scheduledDelay") > 0 && !MissionBanner.isShowing());
+		int cd2 = getInt(Game.class, "transitionCooldown");
+		for (int i = 0; i <= cd2 + 5; i++) {
+			g.update();
+		}
+		check("lore aparece após o cooldown", MissionBanner.isShowing());
+
+		System.out.println("\n=== Results: " + (15 - fails) + " passed, " + fails + " failed ===");
+		System.exit(fails > 0 ? 1 : 0);
+	}
+}

--- a/tools/rodada21_plano.md
+++ b/tools/rodada21_plano.md
@@ -1,0 +1,31 @@
+# Rodada 21 — plano (executar após merge do PR #34)
+
+## Estado atual
+PR #34 mergeado na main (commit 9fda78b). Branch atual: `manus/rodada21-polimento-transicao` (PR a criar — body básico já enviado, mas falhou por ausência de commits; recriar após primeiro commit com `gh pr create --title "Rodada 21 — Transição de fase calmante + polimento" --body ...`).
+
+## Bug reportado pelo usuário (screenshot rodada 21)
+Depois de concluir a fase (diálogo com NPC), o jogo exibe "Fase 2 concluída! / Próxima fase: ... / Missão: ..." mas tudo acontece rápido demais: o aviso some logo e os mobs já atacam. Também aparecem DUAS mensagens sobrepostas ("Fase 2 concluída!" e o banner de lore da nova fase ao mesmo tempo) — na screenshot o menu de pausa aparece desenhado por trás da mensagem de transição.
+
+## Diagnóstico
+1. `advanceToNextLevel()` chama `PhaseStatsScreen.show()` que seta `gameState = "MENU"`, MAS `PhaseStatsScreen` tem `AUTO_DISMISS_FRAMES = 280` e `dismiss()` restaura `gameState = "NORMAL"` → o jogo volta ao combate sozinho.
+2. Na screenshot, o "menu principal" aparece desenhado atrás da mensagem de transição: quando `gameState = "MENU"` e `showLevelTransition > 0`, o render desenha o menu (linha 836-839) AO MESMO TEMPO que o aviso — sobreposição feia.
+3. A nova fase carrega com inimigos já nascendo; não há "respiro" inicial (o WaveManager começa a spawar imediatamente).
+
+## Correções rodadas 21
+1. **Respiro seguro pós-transição (`RESPIRO_FRAMES`)**: após fechar a tela de stats, manter inimigos congelados (pausados, como no onboarding) por ~2,5s (~150 frames) até o jogador ter tempo de se orientar. Nova flag `Game.transitionCooldown > 0` que pausa Enemy.update e WaveManager spawns. O aviso "Fase X concluída!" permanece visível durante o cooldown (não decresce durante cooldown).
+2. **Sem auto-dismiss em `PhaseStatsScreen` durante a campanha**: só fecha por Enter (manter auto-dismiss para modo sobrevivência infinito, onde o jogador não pode travar). Na campanha, fechar por Enter → inicia o cooldown de respiro.
+3. **Não desenhar o menu de pausa sobre o aviso de transição**: no render, quando `showLevelTransition > 0` e `gameState == "MENU"` (stats screen), não renderizar o menu (o card de stats já está visível por cima).
+4. **Fade preto cobre tudo na transição**: garantir `transitionAlpha = 150` persista durante o cooldown (não decair enquanto cooldown > 0).
+5. **Evitar sobreposição de banners**: MissionBanner.showComplete (150 frames) não deve ser cancelado pelo banner de lore que `advanceToNextLevel` dispara (360 frames) — adiar o banner de lore em ~1,5s após o cooldown (ou mostrar lore depois que o usuário apertar Enter).
+6. **Build + suíte completa + teste novo `TransitionCooldownTest` (render simulado: inimigos congelados por N frames após transição, cooldown decrementa)** + commit + push + PR.
+
+## Comandos
+- Build: `cd /home/ubuntu/First-game-in-java && javac -d bin -cp bin $(find src -name "*.java") 2>&1 | grep -v "^Note" | grep error | head -3; echo BUILD_OK`
+- Teste: `out=/tmp/test_X && rm -rf $out && mkdir -p $out && javac -d $out -cp bin:res tools/X.java 2>/dev/null && DISPLAY=:120 timeout 90 java -cp $out:bin:res X 2>&1 | tail -1`
+- Suíte: ObjectivesVariadosTest ShopQaTest MenuNavigationTest PhaseTransitionTest AutoValidate StoryNpcPlacementTest (todos em tools/)
+
+## Backlog futuro (rodadas 22+)
+- Balanceamento fino chefes fases 7/8
+- Mais skins/companions com preview na loja
+- Missões secundárias e diálogos extras
+- Pausa por ESC durante combate (pausa real, hoje ESC só fecha telas)


### PR DESCRIPTION
## Rodada 21 — Transição de fase calmante

Corrige o problema reportado: após concluir a fase, o jogo avançava rápido demais — o aviso de fase concluída sumia e os mobs já atacavam, com o menu desenhando por trás da mensagem.

### Mudanças
- **Cooldown de respiro pós-transição (~2,5s)**: inimigos ficam congelados e o WaveManager não spawna novos lotes; o jogador tem tempo de se orientar na nova fase.
- **Card de estatísticas na campanha só fecha por Enter** (sem auto-dismiss), evitando que o jogo arremesse o jogador ao combate sozinho; no modo infinito o auto-dismiss é mantido.
- **Menu principal não desenha por cima do card/aviso** de transição (tinha textos sobrepostos).
- **Banner de lore agendado**: a ambientação da nova fase só aparece depois do cooldown, sem competir com o card de estatísticas.
- Aplicado em todas as entradas de fase: campanha, modo sobrevivência e modo infinito.

### Testes
- Novo TransitionCooldownTest: 15/15
- Suíte completa verde: ObjectivesVariadosTest 20/20, ShopQaTest 19/19, MenuNavigationTest 12/12, PhaseTransitionTest 24/24, AutoValidate 24/24, StoryNpcPlacementTest 39/39, WaypointFrameTest OK
