### PR TITLE
Rodada 24b — tropas de elite procedurais e recorde de profundidade

### DIFF
--- a/src/com/traduvertgames/entities/Enemy.java
+++ b/src/com/traduvertgames/entities/Enemy.java
@@ -162,6 +162,7 @@ public class Enemy extends Entity {
     private final Color projectileColor;
     private final Color auraColor;
     private final boolean boss;
+    private final boolean elite;
     private boolean furyAnnounced = false;
     private int furySpreadCooldown = 0;
 
@@ -184,10 +185,20 @@ public class Enemy extends Entity {
     }
 
     public Enemy(int x, int y, int width, int height, BufferedImage sprite, Variant variant, boolean boss) {
+        this(x, y, width, height, sprite, variant, boss, false);
+    }
+
+    /**
+     * Construtor com status de elite (rodada 24b): tropas de choque do modo
+     * infinito, com vida e dano de projétil 30% maiores e aura dourada
+     * pulsante. Nunca conta como chefe — é um multiplicador de variante.
+     */
+    public Enemy(int x, int y, int width, int height, BufferedImage sprite, Variant variant, boolean boss, boolean elite) {
         super(x, y, width, height, null);
         this.variant = variant;
         this.boss = boss;
-        this.maxLife = variant.getMaxLife();
+        this.elite = elite;
+        this.maxLife = variant.getMaxLife() * (elite ? 1.3 : 1.0);
         this.life = this.maxLife;
         sprites = new BufferedImage[2];
         if (variant == Variant.PHANTOM) {
@@ -205,13 +216,14 @@ public class Enemy extends Entity {
         this.chaseSpeed = BASE_CHASE_SPEED * variant.getSpeedMultiplier();
         this.strafeSpeed = BASE_STRAFE_SPEED * variant.getStrafeMultiplier();
         this.projectileSpeed = variant.getProjectileSpeed();
-        this.projectileDamage = variant.getProjectileDamage();
         this.projectileSize = variant.getProjectileSize();
-        this.attackCooldownBase = Math.max(variant.getAttackCooldown(), 30);
+        this.projectileDamage = variant.getProjectileDamage();
+        this.damageMultiplierElite = elite ? 1.3 : 1.0;
+        this.attackCooldownBase = Math.max((int) Math.round(variant.getAttackCooldown() * (elite ? 0.9 : 1.0)), 30);
         this.specialCooldownBase = Math.max(0, variant.getSpecialCooldown());
         this.specialRange = variant.getSpecialRange();
         this.projectileColor = variant.getProjectileColor();
-        this.auraColor = variant.getAuraColor();
+        this.auraColor = elite ? new Color(255, 200, 0) : variant.getAuraColor();
         if (this.specialCooldownBase > 0) {
             specialCooldown = Game.rand.nextInt(this.specialCooldownBase);
         }
@@ -386,6 +398,7 @@ public class Enemy extends Entity {
 
     private double lifeBoost = 0.0;
     private double damageBoost = 1.0;
+    private double damageMultiplierElite;
 
     /** @return vida total considerando o reforço de vida do modo sobrevivência. */
     public double getTotalLife() {
@@ -398,14 +411,14 @@ public class Enemy extends Entity {
 
 	/** @return dano efetivo de projétil considerando o reforço do modo sobrevivência. */
 	public double getEffectiveProjectileDamage() {
-		return this.projectileDamage * this.damageBoost;
+		return this.projectileDamage * this.damageBoost * this.damageMultiplierElite;
 	}
 
 	/** XP base concedido ao derrotar este inimigo (bônus para chefes e reforçados). */
 	private int calculateXpGain() {
 		int base = this.boss ? 100 : 10;
 		int combo = com.traduvertgames.main.Game.getComboMultiplier();
-		return Math.max(1, (int) ((base + this.lifeBoost * 0.5)) * Math.min(combo, 5));
+        return Math.max(1, (int) ((base + this.lifeBoost * 0.5) * this.damageMultiplierElite) * Math.min(combo, 5));
 	}
 
     private static Variant pickRandomVariant() {
@@ -1233,6 +1246,11 @@ public class Enemy extends Entity {
         return boss;
     }
 
+    /** Status de elite (rodada 24b): tropas de choque procedurais do modo infinito. */
+    public boolean isElite() {
+        return elite;
+    }
+
     public void render(Graphics g) {
         // Transição de fase: inimigos ficam invisíveis para limpar a tela
         // enquanto o banner de conclusão e o fade preto substituem a cena.
@@ -1258,6 +1276,14 @@ public class Enemy extends Entity {
                 g.setColor(new Color(100, 255, 100, 140));
                 g.drawOval(this.getX() - 1 - Camera.x, this.getY() - 1 - Camera.y, 18, 18);
             }
+        }
+        if (elite) {
+            // Tropas de choque procedurais (rodada 24b): aura dourada pulsante,
+            // sinal visual de que é um inimigo com vida e dano +30%.
+            int pulse = (frames % 40 < 20) ? 190 : 130;
+            int expand = (frames % 40 < 20) ? 2 : 0;
+            g.setColor(new Color(255, 200, 0, pulse));
+            g.drawOval(this.getX() - 1 - expand - Camera.x, this.getY() - 1 - expand - Camera.y, 18 + expand * 2, 18 + expand * 2);
         }
     }
 

--- a/src/com/traduvertgames/entities/SecondaryNpcs.java
+++ b/src/com/traduvertgames/entities/SecondaryNpcs.java
@@ -30,7 +30,10 @@ public final class SecondaryNpcs {
 
 	/** Veterano Rex: missão de eliminações. */
 	public static InteractiveNpc createVeteranRex(int x, int y) {
-		final String questId = "rex_kills_" + com.traduvertgames.quest.QuestManager.getCurrentLevel();
+		int __level = com.traduvertgames.quest.QuestManager.getCurrentLevel();
+		final String questId = __level > com.traduvertgames.main.Game.MAX_LEVEL
+				? "rex_kills_deep"
+				: "rex_kills_" + __level;
 		final int targetKills = 10;
 		return new BranchingNpc(x, y, "Veterano Rex", new Color(120, 60, 40),
 				new Color(255, 224, 178)) {
@@ -47,7 +50,7 @@ public final class SecondaryNpcs {
 													SideQuestManager.Type.KILL_N, null, targetKills,
 													new Reward(60, 20, 0, 150));
 											SideQuestManager.register(quest);
-											SideQuestManager.activate(questId);
+											SideQuestManager.activateIfNeeded(questId);
 										},
 										null, null }),
 						new DialogueNode(
@@ -60,7 +63,7 @@ public final class SecondaryNpcs {
 													SideQuestManager.Type.KILL_N, null, targetKills,
 													new Reward(60, 20, 0, 150));
 											SideQuestManager.register(quest);
-											SideQuestManager.activate(questId);
+											SideQuestManager.activateIfNeeded(questId);
 										},
 										null, null }),
 						new DialogueNode(
@@ -73,7 +76,7 @@ public final class SecondaryNpcs {
 													SideQuestManager.Type.KILL_N, null, targetKills,
 													new Reward(60, 20, 0, 150));
 											SideQuestManager.register(quest);
-											SideQuestManager.activate(questId);
+											SideQuestManager.activateIfNeeded(questId);
 										},
 										null, null }),
 						// 3 — nó de progresso (usado após aceitar e conferir)
@@ -105,7 +108,10 @@ public final class SecondaryNpcs {
 
 	/** Pesquisadora Lila: missão de coleta no inventário. */
 	public static InteractiveNpc createResearcherLila(int x, int y) {
-		final String questId = "lila_collect_" + com.traduvertgames.quest.QuestManager.getCurrentLevel();
+		int __level = com.traduvertgames.quest.QuestManager.getCurrentLevel();
+		final String questId = __level > com.traduvertgames.main.Game.MAX_LEVEL
+				? "lila_collect_deep"
+				: "lila_collect_" + __level;
 		final int targetItems = 3;
 		return new BranchingNpc(x, y, "Pesquisadora Lila", new Color(40, 70, 140),
 				new Color(255, 224, 178)) {
@@ -123,7 +129,7 @@ public final class SecondaryNpcs {
 													InventoryManager.ItemType.ENERGY_CELL,
 													targetItems, new Reward(20, 30, 80, 100));
 											SideQuestManager.register(quest);
-											SideQuestManager.activate(questId);
+											SideQuestManager.activateIfNeeded(questId);
 										},
 										null, null, null }),
 						new DialogueNode(
@@ -141,7 +147,7 @@ public final class SecondaryNpcs {
 													InventoryManager.ItemType.ENERGY_CELL,
 													targetItems, new Reward(20, 30, 80, 100));
 											SideQuestManager.register(quest);
-											SideQuestManager.activate(questId);
+											SideQuestManager.activateIfNeeded(questId);
 										},
 										null, null }),
 						// 3 — recusa

--- a/src/com/traduvertgames/main/Game.java
+++ b/src/com/traduvertgames/main/Game.java
@@ -1780,7 +1780,7 @@ if (!hidingHud) {
 	 * Gera o primeiro mapa procedural, entra no modo arena e exibe o banner de
 	 * transição do modo.
 	 */
-	public static void enterInfiniteMode() {
+		public static void enterInfiniteMode() {
 		if (instance != null) {
 			instance.levelPlus = 1;
 		}
@@ -1793,6 +1793,13 @@ if (!hidingHud) {
 		transitionAlpha = 255;
 		// Trilha sonora adaptativa (rodada 22): tema de arena no modo infinito.
 		MusicManager.setZone(MusicManager.Zone.ARENA);
+		// Rodada 24: a entrada nas Profundezas ganha o banner de lore da trama,
+		// com destaque dourado igual ao das fases de campanha.
+		com.traduvertgames.graficos.MissionBanner.reset();
+		com.traduvertgames.graficos.MissionBanner.scheduleLore(
+				com.traduvertgames.quest.StoryManager.getPhaseLoreTitle(MAX_LEVEL + 1),
+				com.traduvertgames.quest.StoryManager.getPhaseLore(MAX_LEVEL + 1),
+				RESPIRO_FRAMES);
 	}
 
 	/**
@@ -1817,6 +1824,13 @@ if (!hidingHud) {
 		transitionCooldown = RESPIRO_FRAMES;
 		showLevelTransition = 90 + RESPIRO_FRAMES;
 		transitionAlpha = 255;
+		// Rodada 24: cada nova profundidade exibe o banner de lore progressivo
+		// da trama das Profundezas (títulos de ciclo-chave em dourado).
+		com.traduvertgames.graficos.MissionBanner.reset();
+		com.traduvertgames.graficos.MissionBanner.scheduleLore(
+				com.traduvertgames.quest.StoryManager.getPhaseLoreTitle(MAX_LEVEL + depth),
+				com.traduvertgames.quest.StoryManager.getPhaseLore(MAX_LEVEL + depth),
+				RESPIRO_FRAMES);
 	}
 
 	/** Carrega o mapa procedural da profundidade informada. */

--- a/src/com/traduvertgames/main/Game.java
+++ b/src/com/traduvertgames/main/Game.java
@@ -1507,6 +1507,9 @@ if (!hidingHud) {
 		com.traduvertgames.entities.Companion.clear();
 		this.levelPlus = 0;
 		CUR_LEVEL = 1;
+		// Recorde de profundidade (rodada 24b): novo jogo reseta o recorde em memória;
+		// o recorde gravado no save persiste — ao carregar um slot ele é restaurado.
+		com.traduvertgames.main.SaveManager.resetDeepRecord();
 		questCompletedPending = false;
 		shopPendingOpened = false;
 		showLevelTransition = 0;
@@ -1784,6 +1787,9 @@ if (!hidingHud) {
 		if (instance != null) {
 			instance.levelPlus = 1;
 		}
+		// Recorde de profundidade (rodada 24b): registrar a profundidade 1 ao
+		// entrar no modo infinito — persiste no slot e aparece no menu principal.
+		com.traduvertgames.main.SaveManager.setDeepRecord(1);
 		QuestManager.prepareForLevel(MAX_LEVEL + 1);
 		startProceduralLevel(1);
 		WaveManager.startArena();
@@ -1814,6 +1820,9 @@ if (!hidingHud) {
 		}
 		instance.levelPlus += 1;
 		int depth = instance.levelPlus;
+		// Recorde de profundidade (rodada 24b): o avanço de ciclo atualiza o
+		// recorde do slot (só grava se for maior que o anterior).
+		com.traduvertgames.main.SaveManager.setDeepRecord(depth);
 		QuestManager.prepareForLevel(MAX_LEVEL + 1);
 		applyProgressBonuses();
 		// Card de estatísticas do ciclo que acabou de terminar.

--- a/src/com/traduvertgames/main/Game.java
+++ b/src/com/traduvertgames/main/Game.java
@@ -1474,14 +1474,19 @@ if (!hidingHud) {
         }
 
                 private boolean loadGameFromSave() {
+                // Rodada 24: o autosave moderno grava em saves.json — antes,
+                // este método exigia o antigo save.txt que nunca existe, e o
+                // "Reiniciar partida" caía direto em startNewGame (tutorial).
+                // Tentativa 1: autosave do SaveManager (saves.json).
+                if (SaveManager.hasAnySave()) {
+                        if (SaveManager.loadSlot(SaveManager.activeSlot)) {
+                                return true;
+                        }
+                }
+                // Tentativa 2: a codificação manual antiga (legado, save.txt).
                 File file = new File("save.txt");
                 if (!file.exists()) {
                         return false;
-                }
-                // Primeiro tenta o autosave do SaveManager; depois a codificação
-                // manual antiga (legado) como último recurso.
-                if (SaveManager.hasAnySave()) {
-                        return SaveManager.loadSlot(SaveManager.activeSlot);
                 }
                 String saver = Menu.loadGame(20);
                 if (saver == null || saver.isEmpty()) {
@@ -1544,6 +1549,13 @@ if (!hidingHud) {
 	}
 
 	/** Abre a tela de escolha de arma inicial (pausa o jogo no estado NORMAL). */
+	/** Limpa a tela de seleção de arma inicial (usada no carregamento de save — rodada 24). */
+	public static void clearInitialWeaponSelect() {
+		showInitialWeaponSelect = false;
+		initialWeaponSelection = 0;
+		Menu.pause = false;
+	}
+
 	private static void startInitialWeaponSelect() {
 		showInitialWeaponSelect = true;
 		initialWeaponSelection = 0;
@@ -1715,13 +1727,15 @@ if (!hidingHud) {
 		bullets.clear();
 		questCompletedPending = false;
 		shopPendingOpened = false;
-		QuestManager.prepareForLevel(CUR_LEVEL);
-		String newWorld = "level" + CUR_LEVEL + ".png";
-		World.restartGame(newWorld);
 		// Card de estatísticas da fase que acabou de terminar (kills, tempo, combo).
 		// Rodada 21: o card fica pausado na frente do jogo e só fecha por Enter
 		// (sem auto-dismiss na campanha) — a tela não é arremessada ao combate.
+		// Rodada 24: capturado ANTES do World.restartGame — o restart zera os
+		// contadores da fase (resetLevelStats) e o card mostrava tudo zerado.
 		com.traduvertgames.graficos.PhaseStatsScreen.show();
+		QuestManager.prepareForLevel(CUR_LEVEL);
+		String newWorld = "level" + CUR_LEVEL + ".png";
+		World.restartGame(newWorld);
 		// Transição de fase limpa: fade preto total "apaga" a fase antiga
 		// e esmaece rapidamente, revelando a nova fase sem escurecimento
 		// residual (rodada 22c). O HUD fica escondido no meio tempo.

--- a/src/com/traduvertgames/main/Menu.java
+++ b/src/com/traduvertgames/main/Menu.java
@@ -599,15 +599,20 @@ public class Menu {
 		for (int i = 0; i < LOAD_SLOT_LABELS.length; i++) {
 			int slotId = i + 1;
 			String detail = "";
-			if (SaveManager.hasSlotSave(slotId)) {
-				int level = SaveManager.getSlotLevel(slotId);
-				int slotScore = SaveManager.getSlotScore(slotId);
-				int slotSurvival = SaveManager.getSlotSurvivalRecord(slotId);
-				detail = String.format("  (Fase %d — Pontuação %d", level, slotScore);
-				if (slotSurvival > 0) {
-					detail += String.format(" — Sobrevivência: %d ondas", slotSurvival);
-				}
-				detail += ")";
+				if (SaveManager.hasSlotSave(slotId)) {
+					int level = SaveManager.getSlotLevel(slotId);
+					int slotScore = SaveManager.getSlotScore(slotId);
+					int slotSurvival = SaveManager.getSlotSurvivalRecord(slotId);
+					detail = String.format("  (Fase %d — Pontuação %d", level, slotScore);
+					if (slotSurvival > 0) {
+						detail += String.format(" — Sobrevivência: %d ondas", slotSurvival);
+					}
+					// Recorde de profundidade (rodada 24b): maior ciclo do infinito.
+					int slotDeep = SaveManager.getSlotDeepRecord(slotId);
+					if (slotDeep > 0) {
+						detail += String.format(" — Profundidades: %d", slotDeep);
+					}
+					detail += ")";
 			} else {
 				detail = "  (vazio)";
 			}

--- a/src/com/traduvertgames/main/SaveManager.java
+++ b/src/com/traduvertgames/main/SaveManager.java
@@ -477,6 +477,9 @@ public final class SaveManager {
 			restoreObjectiveState(slot, savedLevel);
 			restoreNarrativeFlags(slot);
 			restoreCompanion(session);
+			// Rodada 24: retomada da fase salva sem arremessar o piloto à
+			// tela de seleção de arma inicial (também neste caminho).
+			com.traduvertgames.main.Game.clearInitialWeaponSelect();
 			return true;
 		}
 
@@ -491,6 +494,10 @@ public final class SaveManager {
 		Player.shield = savedShield;
 		Game.gameState = "NORMAL";
 		Menu.pause = false;
+		// Rodada 24: o carregamento retoma a fase salva em vez de arremessar
+		// o piloto de volta à tela de seleção de arma inicial (que parecia um
+		// "tutorial" e travava o retorno ao combate após morrer).
+		com.traduvertgames.main.Game.clearInitialWeaponSelect();
 		activeSlot = slotId;
 		restoreObjectiveState(slot, savedLevel);
 		restoreNarrativeFlags(slot);

--- a/src/com/traduvertgames/main/SaveManager.java
+++ b/src/com/traduvertgames/main/SaveManager.java
@@ -61,7 +61,10 @@ public final class SaveManager {
 	private static final File SAVE_TMP = new File("saves.tmp");
 
 	/** Versão atual do esquema de save emitida na escrita. */
-	public static final int SCHEMA_VERSION = 3;
+	public static final int SCHEMA_VERSION = 4;
+
+	/** Chave do recorde de profundidade do modo infinito por slot (rodada 24b). */
+	private static final String DEEP_RECORD_KEY = "deepRecord";
 
 	/** Chave do snapshot da melhor partida no root do save (global, não por slot). */
 	private static final String BEST_RUN_KEY = "bestRun";
@@ -76,7 +79,8 @@ public final class SaveManager {
 	/** Chave do mapa de flags de diálogos por NPC/fase no progress do slot. */
 	private static final String NPC_DIALOGUES_KEY = "npcDialogues";
 
-	/** Snapshot da melhor partida carregado do arquivo (em memória). */
+	/** Recorde de profundidade carregado do slot ativo (rodada 24b). */
+	private static int deepRecord = 0;
 	private static int bestRunKills = 0;
 	private static long bestRunTimeMs = 0;
 	private static int bestRunCombo = 0;
@@ -120,6 +124,10 @@ public final class SaveManager {
 		slot.put("armaAtual", Player.getCurrentWeaponOrdinal());
 		slot.put("armasDesbloqueadas", Player.getWeaponUnlockMask());
 		slot.put("survivalRecord", com.traduvertgames.main.WaveManager.getSurvivalRecord());
+		// Recorde de profundidade (rodada 24b): a maior profundidade alcançada
+		// no modo infinito deste slot — gravado no nível superior do slot e
+		// herdado pela sessão (construída logo abaixo).
+		slot.put(DEEP_RECORD_KEY, Math.max(toInt(slot.get(DEEP_RECORD_KEY)), deepRecord));
 
 		// Atualiza o recorde global da melhor partida: se qualquer métrica da
 		// fase que acabou de terminar superar o snapshot anterior, o bestRun
@@ -173,6 +181,7 @@ public final class SaveManager {
 		// no menu de carregar sem precisar desaninhar o mapa.
 		slot.put("survivalRecord", com.traduvertgames.main.WaveManager.getSurvivalRecord());
 		slot.put("timestamp", currentTimestamp());
+
 		// Remove as chaves antigas agora duplicadas dentro de session.
 		// A própria chave "session" (de uma gravação anterior do mesmo slot)
 		// também sai do nível superior, pois o conteúdo dela é recriado
@@ -343,6 +352,52 @@ public final class SaveManager {
 		}
 	}
 
+	/** ---------- Recorde de profundidade (rodada 24b) ---------- */
+
+	/** @return maior profundidade do modo infinito já alcançada no slot ativo. */
+	public static int getDeepRecord() {
+		return deepRecord;
+	}
+
+	/** @return recorde de profundidade gravado no slot informado (sem carregar). */
+	public static int getSlotDeepRecord(int slotId) {
+		if (slotId < 1 || slotId > SLOT_COUNT) {
+			return 0;
+		}
+		Map<String, Object> root = loadRoot();
+		List<Map<String, Object>> slots = getSlots(root);
+		Map<String, Object> slot = findSlot(slots, slotId);
+		if (slot == null) {
+			return 0;
+		}
+		int fromSlot = toInt(slot.get(DEEP_RECORD_KEY));
+		int fromSession = toInt(getSession(slot).get(DEEP_RECORD_KEY));
+		return Math.max(fromSlot, fromSession);
+	}
+
+	/** Registra um novo recorde de profundidade do slot ativo (e grava). */
+	public static void setDeepRecord(int depth) {
+		if (depth <= deepRecord) {
+			return;
+		}
+		deepRecord = depth;
+		saveCurrentGame();
+	}
+
+	/** Zera o recorde de profundidade em memória (novo jogo). */
+	public static void resetDeepRecord() {
+		deepRecord = 0;
+	}
+
+	private static void restoreDeepRecord(Map<String, Object> slot) {
+		if (slot == null) {
+			return;
+		}
+		int fromSlot = toInt(slot.get(DEEP_RECORD_KEY));
+		int fromSession = toInt(getSession(slot).get(DEEP_RECORD_KEY));
+		deepRecord = Math.max(fromSlot, fromSession);
+	}
+
 	/** ---------- Leitura ---------- */
 
 	/**
@@ -366,6 +421,9 @@ public final class SaveManager {
 		// Migração v2→v3: snapshot da melhor partida (root) e flags de diálogos.
 		restoreBestRun(root);
 		restoreNpcDialogues(slot);
+
+		// Recorde de profundidade (rodada 24b): maior profundidade do infinito neste slot.
+		restoreDeepRecord(slot);
 
 		// Migração v1→v2: se o slot é flat (v1), a sessão é o próprio slot.
 		Map<String, Object> session = getSession(slot);

--- a/src/com/traduvertgames/quest/SideQuestManager.java
+++ b/src/com/traduvertgames/quest/SideQuestManager.java
@@ -114,6 +114,19 @@ public final class SideQuestManager {
 		}
 	}
 
+	/**
+	 * Ativa a missão apenas se ela ainda não estiver ativa ou concluída.
+	 * Rodada 24: no modo infinito o NPC reaparece a cada profundidade, mas o
+	 * progresso da missão é global do ciclo — reativar apagaria o avanço do
+	 * piloto entre camadas.
+	 */
+	public static void activateIfNeeded(String id) {
+		if (!quests.containsKey(id) || isActive(id) || isCompleted(id)) {
+			return;
+		}
+		activate(id);
+	}
+
 	public static boolean isActive(String id) {
 		return quests.containsKey(id) && progress.containsKey(id) && !isCompleted(id);
 	}

--- a/src/com/traduvertgames/quest/StoryManager.java
+++ b/src/com/traduvertgames/quest/StoryManager.java
@@ -57,14 +57,33 @@ public final class StoryManager {
 				return;
 			}
 		}
-		if (level >= 2 && level <= 8) {
+		// Rodada 24: as missões secundárias acompanham o piloto também nas
+		// Profundezas (modo infinito). Na campanha, os três NPCs aparecem entre
+		// as fases 2 e 8; no modo infinito, cada profundidade mantém um NPC
+		// rotativo (1 por ciclo), para as missões renderem recompensas sem
+		// poluir o layout procedural.
+		boolean inCampaign = level >= 2 && level <= 8;
+		if (inCampaign) {
+			// Campanha (fases 2-8): os três NPCs secundários presentes, cada
+			// um com seu tipo de missão.
 			Game.entities.add(com.traduvertgames.entities.SecondaryNpcs.createVeteranRex(0, 0));
-		}
-		if (level >= 3 && level <= 8) {
 			Game.entities.add(com.traduvertgames.entities.SecondaryNpcs.createResearcherLila(0, 0));
-		}
-		if (level >= 5 && level <= 8) {
 			Game.entities.add(com.traduvertgames.entities.SecondaryNpcs.createMerchantFinn(0, 0));
+		} else if (level > 8) {
+			// Modo infinito (Profundezas): um NPC rotativo por profundidade.
+			int depth = level - 8;
+			switch ((depth - 1) % 3) {
+			case 0:
+			default:
+				Game.entities.add(com.traduvertgames.entities.SecondaryNpcs.createVeteranRex(0, 0));
+				break;
+			case 1:
+				Game.entities.add(com.traduvertgames.entities.SecondaryNpcs.createResearcherLila(0, 0));
+				break;
+			case 2:
+				Game.entities.add(com.traduvertgames.entities.SecondaryNpcs.createMerchantFinn(0, 0));
+				break;
+			}
 		}
 		// Reposiciona os NPCs secundários recém-criados para chão válido,
 		// espalhados dos NPCs da campanha.
@@ -196,9 +215,31 @@ public final class StoryManager {
 		case 8:
 			return "O Núcleo Central";
 		default:
-			return "Sobrevivência — Camada " + (level - 8);
+			// Rodada 24a — narrativa das Profundezas: ciclos-chave a cada 3
+			// profundidades ganham título próprio (Camada Zero, Um, Dois,
+			// Três, Quatro), enquanto os níveis intermediários seguem dois
+			// estilos alternados ("Setor" e "Câmara de Contenção").
+			int depth = level - 8;
+			int keyIdx = (depth - 1) / 3;
+			if ((depth - 1) % 3 == 0) {
+				return DEEP_KEY_TITLES[keyIdx % DEEP_KEY_TITLES.length];
+			}
+			if (depth % 2 == 0) {
+				return "Profundidade " + depth + " — Câmara de Contenção "
+						+ DEEP_SECTION_LETTERS[(depth - 1) % DEEP_SECTION_LETTERS.length];
+			}
+			return "Profundidade " + depth + " — Setor "
+					+ DEEP_SECTION_LETTERS[(depth - 1) % DEEP_SECTION_LETTERS.length];
 		}
 	}
+
+	// Títulos rotativos dos ciclos-chave das Profundezas (trama progressiva).
+	private static final String[] DEEP_KEY_TITLES = { "Camada Zero — A Queda",
+			"Camada Um — O Abismo da IA", "Camada Dois — Ossuário de Ferro",
+			"Camada Três — A Mente Fragmentada",
+			"Camada Quatro — O Eco da Colônia" };
+	// Letras dos setores das profundezas intermediárias.
+	private static final String[] DEEP_SECTION_LETTERS = { "A", "B", "C" };
 
 	/** Linha de lore exibida ao entrar na fase (subtítulo do banner). */
 	public static String getPhaseLore(int level) {
@@ -220,9 +261,29 @@ public final class StoryManager {
 		case 8:
 			return "O Núcleo Central revela a mente por trás da colônia. Esta é a batalha final da campanha.";
 		default:
-			return "A profundidade aumenta. Quantas camadas você consegue sobreviver?";
+			// Rodada 24a — linhas de lore das Profundezas, coerentes com o
+			// título da profundidade correspondente.
+			int depth = level - 8;
+			int keyIdx = (depth - 1) / 3;
+			if ((depth - 1) % 3 == 0) {
+				return DEEP_KEY_LORE[keyIdx % DEEP_KEY_LORE.length];
+			}
+			if (depth % 2 == 0) {
+				return "Unidades de contenção patrulham esta câmara. O Supervisor"
+						+ " mantém reféns do passado da colônia trancados aqui.";
+			}
+			return "Um setor abandonado da colônia. Os sensores capturam"
+					+ " fragmentos de transmissão da mente artificial abaixo.";
 		}
 	}
+
+	// Lore rotativa dos ciclos-chave das Profundezas (subtítulo do banner).
+	private static final String[] DEEP_KEY_LORE = {
+			"A primeira queda. O que era a superfície virou ruína — e algo ainda responde aos nossos sinais.",
+			"Os restos da inteligência que governava a colônia se dissolvem neste abismo. Ela ainda ouve.",
+			"Guardiões de ferro guardam o que restou das tripulações anteriores. Nenhum piloto voltou.",
+			"A mente da colônia se despedaçou em ecos. Cada fragmento repete uma ordem que ninguém mais entende.",
+			"No fundo, o eco da colônia sussurra o nome de quem construiu tudo isso. Continue descendo." };
 
 	/** NPCs presentes na fase, para o HUD narrativo. */
 	public static String getStoryNpcsLabel(int level) {

--- a/src/com/traduvertgames/world/ProceduralLevelGenerator.java
+++ b/src/com/traduvertgames/world/ProceduralLevelGenerator.java
@@ -24,6 +24,9 @@ import javax.imageio.ImageIO;
  *   câmaras) que variam abertura das salas e pilares;
  * - inimigos aleatórios (255,0,0) e variantes coloridas proporcionalmente
  *   à profundidade, com cap de densidade ({@value MAX_ENEMY_TARGET});
+ * - tropas de elite (amarelo-dourado, {@value ELITE}) a partir da profundidade
+ *   3, com cap progressivo — viram inimigos de variante sólida com aura
+ *   dourada e vida/dano +30% (rodada 24b);
  * - um chefe fixo (GUARDIAN/WARBRINGER/OVERSEER_PRIME em rotação) por ciclo;
  * - itens de suprimento (LifePack/NanoMedkit) para manter o arco justo.
  *
@@ -47,6 +50,8 @@ public final class ProceduralLevelGenerator {
 	private static final Color GUARDIAN = new Color(255, 87, 34, 255);
 	private static final Color WARBRINGER = new Color(233, 30, 99, 255);
 	private static final Color OVERSEER_PRIME = new Color(208, 25, 55, 255);
+	/** Pixel de tropas de elite procedurais (rodada 24b): amarelo-dourado. */
+	private static final Color ELITE = new Color(255, 200, 0, 255);
 	private static final Color LIFEPACK = new Color(76, 255, 0, 255);
 	private static final Color NANO = new Color(255, 82, 82, 255);
 	private static final Color PLAYER = new Color(0, 38, 255, 255);
@@ -232,25 +237,43 @@ public final class ProceduralLevelGenerator {
 			if (Math.hypot(x - PLAYER_SPAWN_X, y - PLAYER_SPAWN_Y) < 6) {
 				continue;
 			}
-			if (map.getRGB(x, y) != BLACK.getRGB()) {
-				continue;
+				if (map.getRGB(x, y) != BLACK.getRGB()) {
+					continue;
+				}
+				// Rolagem da ocupação: a maioria inimigos, alguns itens.
+				// Rodada 24b: tropas de elite (amarelo-dourado) entram a partir da
+				// profundidade 3, com cap progressivo de 1 + depth/3 por mapa.
+				int eliteCount = countColor(map, w, h, ELITE.getRGB());
+				int eliteCap = 1 + depth / 3;
+				int roll = rng.nextInt(100);
+				Color color;
+				if (roll < 70) {
+					// Inimigo: genérico ou variante conforme a profundidade.
+					color = depth >= 3 && eliteCount < eliteCap && rng.nextInt(4) == 0 ? ELITE
+							: depth >= 3 && rng.nextInt(3) == 0 ? WARDEN
+									: depth >= 2 && rng.nextInt(4) == 0 ? SENTINEL
+											: rng.nextInt(6) == 0 ? RAVAGER : ENEMY;
+				} else if (roll < 88) {
+					color = rng.nextBoolean() ? LIFEPACK : NANO;
+				} else {
+					continue; // célula vazia (chão)
+				}
+				map.setRGB(x, y, color.getRGB());
+				placed++;
 			}
-			// Rolagem da ocupação: a maioria inimigos, alguns itens.
-			int roll = rng.nextInt(100);
-			Color color;
-			if (roll < 70) {
-				// Inimigo: genérico ou variante conforme a profundidade.
-				color = depth >= 3 && rng.nextInt(3) == 0 ? WARDEN
-						: depth >= 2 && rng.nextInt(4) == 0 ? SENTINEL
-								: rng.nextInt(6) == 0 ? RAVAGER : ENEMY;
-			} else if (roll < 88) {
-				color = rng.nextBoolean() ? LIFEPACK : NANO;
-			} else {
-				continue; // célula vazia (chão)
-			}
-			map.setRGB(x, y, color.getRGB());
-			placed++;
 		}
+
+	/** @return número de ocorrências do pixel rgb no mapa (rodada 24b). */
+	private static int countColor(BufferedImage map, int w, int h, int rgb) {
+		int count = 0;
+		for (int y = 0; y < h; y++) {
+			for (int x = 0; x < w; x++) {
+				if (map.getRGB(x, y) == rgb) {
+					count++;
+				}
+			}
+		}
+		return count;
 	}
 
 	/** Posiciona o chefe fixo do ciclo (rotação WARBRINGER → GUARDIAN → OVERSEER_PRIME). */
@@ -318,7 +341,7 @@ public final class ProceduralLevelGenerator {
 					bossCount++;
 				} else if (rgb == BLACK.getRGB() || rgb == WALL.getRGB() || rgb == DESTRUCT.getRGB()
 						|| rgb == ENEMY.getRGB() || rgb == WARDEN.getRGB() || rgb == SENTINEL.getRGB()
-						|| rgb == RAVAGER.getRGB() || rgb == LIFEPACK.getRGB() || rgb == NANO.getRGB()) {
+						|| rgb == RAVAGER.getRGB() || rgb == ELITE.getRGB() || rgb == LIFEPACK.getRGB() || rgb == NANO.getRGB()) {
 					if (rgb == BLACK.getRGB()) {
 						floorCount++;
 					}

--- a/src/com/traduvertgames/world/World.java
+++ b/src/com/traduvertgames/world/World.java
@@ -226,6 +226,29 @@ Game.enemies.add(en);
 									Enemy.Variant.GUARDIAN, false);
 							Game.entities.add(en);
 							Game.enemies.add(en);
+						} else if (pixelAtual == 0xFFFFC800) {
+							// Tropas de elite procedurais (rodada 24b): variante sólida
+							// determinada deterministicamente pela posição, com aura
+							// dourada e vida/dano +30% — nunca conta como chefe.
+							Enemy.Variant eliteVariant;
+							switch ((xx + yy) % 4) {
+								case 0:
+									eliteVariant = Enemy.Variant.WARDEN;
+									break;
+								case 1:
+									eliteVariant = Enemy.Variant.SENTINEL;
+									break;
+								case 2:
+									eliteVariant = Enemy.Variant.RAVAGER;
+									break;
+								default:
+									eliteVariant = Enemy.Variant.SCOUT;
+									break;
+							}
+							Enemy en = new Enemy(xx * 16, yy * 16, 16, 16, Entity.ENEMY_EN,
+									eliteVariant, false, true);
+							Game.entities.add(en);
+							Game.enemies.add(en);
 						} else if (pixelAtual == 0xFFD01937) {
 						// Supervisor-Prime: a mente da colônia, chefe final da campanha (fase 8).
 						Enemy en = new Enemy(xx * 16, yy * 16, 16, 16, Entity.ENEMY_EN,

--- a/tools/Rodada24aDeepLoreTest.java
+++ b/tools/Rodada24aDeepLoreTest.java
@@ -1,0 +1,93 @@
+import com.traduvertgames.quest.StoryManager;
+
+/**
+ * Rodada 24a — QA da narrativa das Profundezas.
+ *
+ * Valida (a) que os ciclos-chave das Profundezas (profundidades 1, 4, 7, 10,
+ * 13 — ou seja, níveis 9, 12, 15, 18, 21) têm títulos e linhas de lore
+ * distintos da nomenclatura genérica; (b) que os níveis intermediários seguem
+ * os dois estilos alternados; (c) que a trama progressiva se mantém coerente
+ * (não repete um mesmo par título+lore em ciclos consecutivos); e (d) que as
+ * fases de campanha (1-8) continuam intactas.
+ */
+public class Rodada24aDeepLoreTest {
+
+	private static int passed = 0;
+	private static int failed = 0;
+
+	private static void check(boolean condition, String description) {
+		if (condition) {
+			passed++;
+			System.out.println("PASS: " + description);
+		} else {
+			failed++;
+			System.out.println("FAIL: " + description);
+		}
+	}
+
+	public static void main(String[] args) {
+		// ---- (d) As fases de campanha continuam intactas ----
+		check("Operação Socorro".equals(StoryManager.getPhaseLoreTitle(1)),
+				"Fase 1: título de lore da campanha preservado");
+		check("O Núcleo Central".equals(StoryManager.getPhaseLoreTitle(8)),
+				"Fase 8: título de lore da campanha preservado");
+		check(StoryManager.getPhaseLore(8).contains("batalha final"),
+				"Fase 8: subtítulo de lore da campanha preservado");
+
+		// ---- (a) Ciclos-chave têm identidade de lore própria ----
+		String[] keyDepths = new String[] { "Camada Zero", "Camada Um",
+				"Camada Dois", "Camada Três", "Camada Quatro" };
+		for (int i = 0; i < keyDepths.length; i++) {
+			int level = 9 + i * 3; // profundidades 1, 4, 7, 10, 13
+			String title = StoryManager.getPhaseLoreTitle(level);
+			check(title.startsWith(keyDepths[i]),
+					"Profundidade " + (i + 1) + " (nível " + level
+							+ "): título de ciclo-chave começa com '"
+							+ keyDepths[i] + "' (obtido: '" + title + "')");
+			String lore = StoryManager.getPhaseLore(level);
+			check(lore != null && lore.length() > 40,
+					"Profundidade " + (i + 1) + ": linha de lore substancial");
+		}
+
+		// ---- (b) Níveis intermediários seguem os estilos alternados ----
+		// depth % 3 == 0 → estilo genérico "Setor" (ex.: profundidade 3, nível 11);
+		// depth % 3 == 2 → "Câmara de Contenção" (ex.: profundidade 2, nível 10).
+		check(StoryManager.getPhaseLoreTitle(11).startsWith("Profundidade 3")
+					&& StoryManager.getPhaseLoreTitle(11).contains("Setor"),
+			"Profundidade 3 (nível 11): estilo 'Setor'");
+		check(StoryManager.getPhaseLoreTitle(10).contains("Câmara de Contenção"),
+			"Profundidade 2 (nível 10): estilo 'Câmara de Contenção'");
+
+		// ---- (c) A trama progressiva não se repete em ciclos consecutivos ----
+		String previousTitle = StoryManager.getPhaseLoreTitle(9);
+		String previousLore = StoryManager.getPhaseLore(9);
+		boolean narrativeMoves = true;
+		boolean loreUnique = true;
+		for (int depth = 2; depth <= 15; depth++) {
+			int level = 8 + depth;
+			String title = StoryManager.getPhaseLoreTitle(level);
+			String lore = StoryManager.getPhaseLore(level);
+			if (title.equals(previousTitle)) {
+				narrativeMoves = false;
+			}
+			if (depth > 1 && lore.equals(previousLore)) {
+				loreUnique = false;
+			}
+			previousTitle = title;
+			previousLore = lore;
+		}
+		check(narrativeMoves,
+				"Trama: nenhum ciclo-chave repete o título do anterior");
+		check(loreUnique,
+				"Trama: linhas de lore não se repetem entre ciclos vizinhos");
+
+		// ---- Rotatividade dos vetores: profundidades além do 13 reciclam ----
+		String title16 = StoryManager.getPhaseLoreTitle(8 + 16);
+		check(title16 != null && title16.length() > 0,
+				"Profundidade 16 (nível 24): título gerado sem exceção ('"
+						+ title16 + "')");
+
+		System.out.println("Progresso: " + passed + " passaram, " + failed + " falharam");
+		System.exit(failed == 0 ? 0 : 1);
+	}
+}

--- a/tools/Rodada24aReportTest.java
+++ b/tools/Rodada24aReportTest.java
@@ -1,0 +1,154 @@
+import com.traduvertgames.main.Game;
+import com.traduvertgames.main.SaveManager;
+import com.traduvertgames.main.OnboardingManager;
+import com.traduvertgames.quest.QuestManager;
+import com.traduvertgames.graficos.PhaseStatsScreen;
+import com.traduvertgames.world.World;
+import java.awt.image.BufferedImage;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * Rodada 24a — reproduz os dois bugs reportados pelo jogador:
+ * (1) card "Fase Concluída" mostra kills/tempo/combo zerados;
+ * (2) ao morrer e reiniciar, o jogo volta ao tutorial.
+ */
+public class Rodada24aReportTest {
+	private static int passed = 0;
+	private static int failed = 0;
+
+	private static void check(boolean condition, String description) {
+		if (condition) {
+			passed++;
+			System.out.println("PASS: " + description);
+		} else {
+			failed++;
+			System.out.println("FAIL: " + description);
+		}
+	}
+
+	public static void main(String[] args) throws Exception {
+		// Limpa saves residuais para isolar o cenário.
+		new java.io.File("saves.json").delete();
+
+		Game g = new Game();
+		Game.setCurrentLevel(1);
+		Game.SCALE = 4;
+		Game.player = new com.traduvertgames.entities.Player(200, 100, 16, 16,
+				new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB));
+		World.restartGame("level1.png");
+
+		System.out.println("=== BUG 1: STATS ZERADOS NO CARD DE FASE CONCLUÍDA ===");
+
+		// Simula o progresso da fase 1: kills, combo e tempo decorrido.
+		Game.registerEnemyKill();
+		Game.registerEnemyKill();
+		Game.setBestComboThisRun(4);
+
+		check(Game.getKillsThisLevel() == 2, "Pré-transição: kills da fase acumulados (2)");
+		check(Game.getBestComboThisRun() >= 4, "Pré-transição: combo máximo da fase >= 4");
+
+		// Avança de fase como o jogo faz ao concluir o objetivo.
+		Game.advanceToNextLevel();
+
+		// O card de estatísticas captura os valores da fase que acabou de
+		// terminar em seus campos internos — os estáticos do Game já foram
+		// zerados pelo restart, mas o card deve ter gravado tudo antes disso.
+		check(getCardKills() == 2,
+				"Pós-transição: kills da fase gravados no card (era " + getCardKills() + ")");
+		// Em ambiente headless (sem game loop rodando), o timer real decorrido
+		// é de poucos milissegundos — o que importa é que o card captura o
+		// tempo da fase que terminou (não mais 0, como acontecia antes).
+		check(getCardTimeMs() > 0,
+				"Pós-transição: tempo da fase gravado no card (era 0)");
+		check(getCardCombo() >= 4,
+				"Pós-transição: combo máximo gravado no card (era " + getCardCombo() + ")");
+
+		// Melhora no total acumulado da campanha (score) deve seguir visível.
+		check(Game.getScore() >= 200,
+				"Pós-transição: score acumulado preservado (" + Game.getScore() + ")");
+
+		System.out.println("=== BUG 2: RESTART PÓS-MORTE VOLTA AO TUTORIAL ===");
+
+		// Recria o jogo na fase 1 para isolar o cenário reportado: morrer na
+		// fase 1, apertar "Reiniciar partida" e verificar se o jogo retoma a
+		// fase salva em vez de cair no tutorial/tela de escolha de arma.
+		Game g2 = new Game();
+		Game.setCurrentLevel(1);
+		Game.SCALE = 4;
+		Game.player = new com.traduvertgames.entities.Player(200, 100, 16, 16,
+				new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB));
+		World.restartGame("level1.png");
+		Game.clearInitialWeaponSelect();
+		// O timer da fase precisa estar em andamento para o save ser válido.
+		Thread.sleep(1200);
+
+		SaveManager.saveAutoSave();
+		check(SaveManager.hasAnySave(), "Autosave criado ao morrer");
+		int deadLevel = Game.getCurrentLevel();
+		check(deadLevel == 1, "Cenário: morte acontece na fase 1");
+
+		// handleGameOverRestart é privado — o teste invoca via reflection,
+		// simulando exatamente o que o update() chama ao marcar restartGame.
+		Method hgr = Game.class.getDeclaredMethod("handleGameOverRestart");
+		hgr.setAccessible(true);
+		hgr.invoke(g2);
+
+		check(!OnboardingManager.isActive(),
+				"Restart pós-morte: tutorial NÃO reaparece");
+		check(!isShowInitialWeaponSelect(),
+				"Restart pós-morte: tela de escolha de arma inicial fechada");
+		check(Game.getCurrentLevel() == deadLevel,
+				"Restart pós-morte: retorna à fase " + deadLevel
+						+ " em que o jogador morreu (não cai em tela inicial)");
+		check("NORMAL".equals(Game.gameState),
+				"Restart pós-morte: estado do jogo é NORMAL (jogando a fase)");
+
+		// Limpa o save de teste.
+		new java.io.File("saves.json").delete();
+
+		System.out.println("Progresso: " + passed + " passaram, " + failed + " falharam");
+		System.exit(failed == 0 ? 0 : 1);
+	}
+
+	private static boolean isShowInitialWeaponSelect() throws Exception {
+		Field f = Game.class.getDeclaredField("showInitialWeaponSelect");
+		f.setAccessible(true);
+		return f.getBoolean(null);
+	}
+
+	// ---- Acesso aos valores capturados pelo PhaseStatsScreen (rodada 24) ----
+	private static int getCardKills() throws Exception {
+		return readIntCard("capturedKills");
+	}
+
+	private static long getCardTimeMs() throws Exception {
+		return readLongCard("capturedTimeMs");
+	}
+
+	private static int getCardCombo() throws Exception {
+		return readIntCard("capturedBestCombo");
+	}
+
+	private static int readIntCard(String field) throws Exception {
+		Class<?> clazz = com.traduvertgames.graficos.PhaseStatsScreen.class;
+		try {
+			Field f = clazz.getDeclaredField(field);
+			f.setAccessible(true);
+			return (int) f.getLong(null);
+		} catch (NoSuchFieldException e) {
+			return -1;
+		}
+	}
+
+	private static long readLongCard(String field) throws Exception {
+		Class<?> clazz = com.traduvertgames.graficos.PhaseStatsScreen.class;
+		try {
+			Field f = clazz.getDeclaredField(field);
+			f.setAccessible(true);
+			return f.getLong(null);
+		} catch (NoSuchFieldException e) {
+			return -1;
+		}
+	}
+}

--- a/tools/Rodada24aSideQuestTest.java
+++ b/tools/Rodada24aSideQuestTest.java
@@ -1,0 +1,163 @@
+import java.awt.image.BufferedImage;
+
+import com.traduvertgames.dialogue.BranchingNpc;
+import com.traduvertgames.dialogue.InteractiveNpc;
+import com.traduvertgames.entities.Player;
+import com.traduvertgames.main.Game;
+import com.traduvertgames.quest.QuestManager;
+import com.traduvertgames.quest.SideQuestManager;
+import com.traduvertgames.quest.StoryManager;
+import com.traduvertgames.world.World;
+
+/**
+ * Rodada 24a — QA das missões secundárias no modo infinito.
+ *
+ * Valida que as missões secundárias (Veterano Rex, Pesquisadora Lila e
+ * Mercador Finn) funcionam nas Profundezas: o NPC correto spawna em cada
+ * profundidade, a missão é ativa ao aceitar, o progresso acompanha kills e
+ * não é apagado entre camadas (questId global do ciclo infinito).
+ */
+public class Rodada24aSideQuestTest {
+
+	private static int passed = 0;
+	private static int failed = 0;
+
+	private static void check(boolean condition, String description) {
+		if (condition) {
+			passed++;
+			System.out.println("PASS: " + description);
+		} else {
+			failed++;
+			System.out.println("FAIL: " + description);
+		}
+	}
+
+	private static Game newGame() throws java.io.IOException {
+		Game g = new Game();
+		Game.SCALE = 4;
+		Game.player = new Player(200, 100, 16, 16,
+				new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB));
+		return g;
+	}
+
+	public static void main(String[] args) throws Exception {
+	// ---- Campanha continua intacta: NPCs das fases 2-8 ----
+	Game g1 = newGame();
+	SideQuestManager.reset();
+	World.restartGame("level3.png");
+		boolean hasRex = Game.entities.stream()
+				.anyMatch(e -> e instanceof com.traduvertgames.dialogue.InteractiveNpc
+						&& ((com.traduvertgames.dialogue.InteractiveNpc) e).getName().contains("Rex"));
+		check(hasRex, "Fase 3 (campanha): Veterano Rex presente");
+
+		// ---- Modo infinito: NPC rotativo por profundidade ----
+		SideQuestManager.reset();
+
+		// Profundidade 1 (nível 9) → Rex
+		Game.setCurrentLevel(9);
+		Game.entities.clear();
+		Game.SCALE = 4;
+		Game.player = new Player(200, 100, 16, 16,
+				new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB));
+		World.restartGame("level8.png"); // fallback: mapa da fase 8 para testes
+		Game.setCurrentLevel(9);
+		QuestManager.prepareForLevel(9);
+		Game.entities.clear();
+		StoryManager.placeStoryNpcs();
+		boolean rex9 = Game.entities.stream()
+				.anyMatch(e -> e instanceof com.traduvertgames.dialogue.InteractiveNpc
+						&& ((com.traduvertgames.dialogue.InteractiveNpc) e).getName().contains("Rex"));
+		check(rex9, "Profundidade 1 (nível 9): Veterano Rex spawna");
+		check(!Game.entities.stream()
+						.anyMatch(e -> e instanceof com.traduvertgames.dialogue.InteractiveNpc
+								&& ((com.traduvertgames.dialogue.InteractiveNpc) e).getName().contains("Lila")),
+				"Profundidade 1: apenas um NPC secundário (rotação sem poluição)");
+
+		// ---- Profundidade 2 (nível 10) → Lila ----
+		SideQuestManager.reset();
+		Game.entities.clear();
+		Game.setCurrentLevel(10);
+		QuestManager.prepareForLevel(10);
+		StoryManager.placeStoryNpcs();
+		boolean lila10 = Game.entities.stream()
+				.anyMatch(e -> e instanceof com.traduvertgames.dialogue.InteractiveNpc
+						&& ((com.traduvertgames.dialogue.InteractiveNpc) e).getName().contains("Lila"));
+		check(lila10, "Profundidade 2 (nível 10): Pesquisadora Lila spawna");
+
+		// ---- Profundidade 3 (nível 11) → Finn ----
+		SideQuestManager.reset();
+		Game.entities.clear();
+		Game.setCurrentLevel(11);
+		QuestManager.prepareForLevel(11);
+		StoryManager.placeStoryNpcs();
+		boolean finn11 = Game.entities.stream()
+				.anyMatch(e -> e instanceof com.traduvertgames.dialogue.InteractiveNpc
+						&& ((com.traduvertgames.dialogue.InteractiveNpc) e).getName().contains("Finn"));
+		check(finn11, "Profundidade 3 (nível 11): Mercador Finn spawna");
+
+		// ---- QuestId global no modo infinito: missão não zera entre camadas ----
+		SideQuestManager.reset();
+		World.restartGame("level8.png");
+		Game.setCurrentLevel(9);
+		QuestManager.prepareForLevel(9);
+		Game.entities.clear();
+		StoryManager.placeStoryNpcs();
+		// Simula o diálogo de aceite do Rex no nível 9
+		InteractiveNpc rex = (InteractiveNpc) Game.entities.stream()
+				.filter(e -> e instanceof InteractiveNpc
+						&& ((InteractiveNpc) e).getName().contains("Rex"))
+				.findFirst().orElse(null);
+		boolean rexAvailable = rex != null;
+		check(rexAvailable, "NPC Rex recuperável para o diálogo de aceite");
+		if (rexAvailable) {
+			// Aceita a missão (nó 0 → opção "Aceitar a missão")
+			BranchingNpc branchRex = (BranchingNpc) rex;
+			branchRex.selectChoice(0);
+			check(SideQuestManager.get("rex_kills_deep") != null,
+					"Missão rex_kills_deep registrada no modo infinito");
+			check(SideQuestManager.isActive("rex_kills_deep"),
+					"Missão da Profundidade 1 fica ativa ao aceitar");
+
+			// Progrida 4 kills e avance para a profundidade 2
+			com.traduvertgames.entities.Enemy phantom = com.traduvertgames.entities.Enemy.spawnRandomVariant(300, 200);
+			for (int i = 0; i < 4; i++) {
+				SideQuestManager.onEnemyKilled(phantom);
+			}
+			check(SideQuestManager.getProgress("rex_kills_deep") == 4,
+					"Progresso da bounty acompanha os kills (4/10)");
+
+							Game.setCurrentLevel(10);
+		QuestManager.prepareForLevel(10);
+		Game.entities.clear();
+		StoryManager.placeStoryNpcs();
+		BranchingNpc branchRex2 = (BranchingNpc) Game.entities.stream()
+					.filter(e -> e instanceof BranchingNpc
+							&& ((BranchingNpc) e).getName().contains("Rex"))
+					.findFirst().orElse(null);
+			// Reaparece na profundidade 2 e "re-aceita": o progresso NÃO pode zerar
+			if (branchRex2 != null) {
+				branchRex2.selectChoice(0);
+			}
+			check(SideQuestManager.getProgress("rex_kills_deep") == 4,
+					"Progresso preservado entre profundidades (não reativa o zero)");
+
+			// Conclui a bounty
+			for (int i = 0; i < 6; i++) {
+				SideQuestManager.onEnemyKilled(phantom);
+			}
+			check(SideQuestManager.isCompleted("rex_kills_deep"),
+					"Bounty da Profundidade concluída com 10 kills (recompensa entregue)");
+		}
+
+		// ---- Na campanha o id continua por fase (sem colisão) ----
+		SideQuestManager.reset();
+		Game.setCurrentLevel(3);
+		QuestManager.prepareForLevel(3);
+		check(SideQuestManager.get("rex_kills_deep") == null,
+				"Campanha: id da Profundidade não é registrado antes do aceite");
+		SideQuestManager.reset();
+
+		System.out.println("Progresso: " + passed + " passaram, " + failed + " falharam");
+		System.exit(failed == 0 ? 0 : 1);
+	}
+}

--- a/tools/Rodada24bDeepRecordTest.java
+++ b/tools/Rodada24bDeepRecordTest.java
@@ -1,0 +1,72 @@
+import java.io.File;
+import com.traduvertgames.main.SaveManager;
+import com.traduvertgames.main.Game;
+
+/**
+ * Rodada 24b — recorde de profundidade do modo infinito.
+ * Valida: setDeepRecord grava e persiste em saves.json; não regride;
+ * restaurado no carregamento do slot; novo jogo reseta em memória;
+ * exibido pela tela de carregar jogo (getSlotDeepRecord).
+ */
+public class Rodada24bDeepRecordTest {
+
+    private static int pass = 0;
+    private static int fail = 0;
+
+    static void check(String name, boolean ok) {
+        if (ok) {
+            pass++;
+            System.out.println("PASS: " + name);
+        } else {
+            fail++;
+            System.out.println("FAIL: " + name);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Estado limpo: nenhum save gravado.
+        Game g = new Game();
+        Game.SCALE = 4;
+
+        // 1. Recorde inicial vazio.
+        SaveManager.activeSlot = 1;
+        check("Recorde inicial é 0", SaveManager.getDeepRecord() == 0);
+
+        // 2. setDeepRecord grava no slot ativo e persiste no arquivo.
+        SaveManager.setDeepRecord(5);
+        check("setDeepRecord(5) atualiza em memória", SaveManager.getDeepRecord() == 5);
+        String json = new String(java.nio.file.Files.readAllBytes(SaveManager.SAVE_FILE.toPath()));
+        boolean persisted = SaveManager.SAVE_FILE.exists() && json.contains("\"deepRecord\"");
+        check("Recorde gravado em saves.json", persisted);
+
+        // 3. Não regride com profundidade menor.
+        SaveManager.setDeepRecord(3);
+        check("Não regride (5 -> 3 mantido)", SaveManager.getDeepRecord() == 5);
+        SaveManager.setDeepRecord(5);
+        check("Mesmo valor não regrava (5 -> 5 mantido)", SaveManager.getDeepRecord() == 5);
+        SaveManager.setDeepRecord(9);
+        check("Avança com profundidade maior", SaveManager.getDeepRecord() == 9);
+
+        // 4. getSlotDeepRecord lê do disco sem carregar o slot.
+        int fromDisk = SaveManager.getSlotDeepRecord(1);
+        check("getSlotDeepRecord(1) reflete o disco", fromDisk == 9);
+        check("Slot inexistente retorna 0", SaveManager.getSlotDeepRecord(2) == 0);
+        check("Slot fora da faixa retorna 0", SaveManager.getSlotDeepRecord(0) == 0);
+
+        // 5. Novo jogo reseta o recorde em memória.
+        g.startNewGame();
+        check("startNewGame reseta em memória", SaveManager.getDeepRecord() == 0);
+        // O valor gravado no save persiste até ser sobrescrito.
+        check("Gravado no disco sobrevive ao novo jogo", SaveManager.getSlotDeepRecord(1) == 9);
+
+        // 6. Carregar o slot restaura o recorde.
+        Game.player = new com.traduvertgames.entities.Player(200, 100, 16, 16,
+                new java.awt.image.BufferedImage(16, 16, java.awt.image.BufferedImage.TYPE_INT_ARGB));
+        boolean loaded = SaveManager.loadSlot(1);
+        check("Slot carregado", loaded);
+        check("loadSlot restaura recorde = 9", SaveManager.getDeepRecord() == 9);
+
+        System.out.println("Progresso: " + pass + " passaram, " + fail + " falharam");
+        System.exit(fail == 0 ? 0 : 1);
+    }
+}

--- a/tools/Rodada24bEliteTest.java
+++ b/tools/Rodada24bEliteTest.java
@@ -1,0 +1,101 @@
+import java.awt.image.BufferedImage;
+import java.io.File;
+import com.traduvertgames.entities.Enemy;
+import com.traduvertgames.entities.Entity;
+import com.traduvertgames.main.Game;
+import com.traduvertgames.world.ProceduralLevelGenerator;
+
+/**
+ * Rodada 24b — tropas de elite procedurais.
+ * Valida: vida/dano +30%, aura dourada (isElite), aparecem só a partir da
+ * profundidade 3 (com cap), nunca contam como chefe e o mapa com elites
+ * passa na validação estrutural.
+ */
+public class Rodada24bEliteTest {
+
+    private static int pass = 0;
+    private static int fail = 0;
+
+    static void check(String name, boolean ok) {
+        if (ok) {
+            pass++;
+            System.out.println("PASS: " + name);
+        } else {
+            fail++;
+            System.out.println("FAIL: " + name);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Inicializa a engine (sem janela visível — Xvfb em DISPLAY=:120).
+        Game g = new Game();
+        Game.SCALE = 4;
+        Game.setCurrentLevel(1);
+        Game.player = new com.traduvertgames.entities.Player(200, 100, 16, 16,
+                new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB));
+
+        // 1. Inimigo comum não é elite; elite tem vida e dano +30% comparados
+        //    ao irmão comum da mesma variante.
+        Enemy normal = new Enemy(100, 100, 16, 16, Entity.ENEMY_EN,
+                Enemy.Variant.WARDEN, false, false);
+        check("Comum não é elite", !normal.isElite());
+
+        Enemy elite = new Enemy(100, 100, 16, 16, Entity.ENEMY_EN,
+                Enemy.Variant.WARDEN, false, true);
+        check("Elite marcado como elite", elite.isElite());
+        check("Elite: vida +30% sobre o comum",
+                Math.abs(elite.getTotalLife() - normal.getTotalLife() * 1.3) < 0.001);
+        check("Elite: dano de projétil +30% sobre o comum",
+                Math.abs(elite.getEffectiveProjectileDamage() - normal.getEffectiveProjectileDamage() * 1.3)
+                        < 0.001);
+        check("Elite nunca é chefe", !elite.isBoss());
+
+        // 2. Profundidade 1 e 2 não geram elites; profundidade 3+ sim.
+        File f1 = ProceduralLevelGenerator.generate(1);
+        BufferedImage m1 = javax.imageio.ImageIO.read(f1);
+        check("Depth 1: sem pixel elite", countPixel(m1, 0xFFFFC800) == 0);
+        check("Depth 1: mapa válido", ProceduralLevelGenerator.validate(m1));
+
+        File f2 = ProceduralLevelGenerator.generate(2);
+        BufferedImage m2 = javax.imageio.ImageIO.read(f2);
+        check("Depth 2: sem pixel elite", countPixel(m2, 0xFFFFC800) == 0);
+
+        File f3 = ProceduralLevelGenerator.generate(3);
+        BufferedImage m3 = javax.imageio.ImageIO.read(f3);
+        int elites3 = countPixel(m3, 0xFFFFC800);
+        check("Depth 3: elite presente", elites3 >= 1);
+        check("Depth 3: elite dentro do cap (1 + depth/3 = 2)", elites3 <= 2);
+        check("Depth 3: mapa válido", ProceduralLevelGenerator.validate(m3));
+
+        // 3. Cap cresce com a profundidade.
+        File f9 = ProceduralLevelGenerator.generate(9);
+        BufferedImage m9 = javax.imageio.ImageIO.read(f9);
+        int elites9 = countPixel(m9, 0xFFFFC800);
+        check("Depth 9: cap = 1 + 9/3 = 4", elites9 <= 4);
+        check("Depth 9: pelo menos 1 elite", elites9 >= 1);
+        check("Depth 9: mapa válido", ProceduralLevelGenerator.validate(m9));
+
+        // 4. Determinismo por semente: mesma profundidade gera o mesmo mapa.
+        File f3b = ProceduralLevelGenerator.generate(3);
+        BufferedImage m3b = javax.imageio.ImageIO.read(f3b);
+        check("Determinismo: mesma semente = mesmo mapa", m3.getRGB(20, 20) == m3b.getRGB(20, 20)
+                && countPixel(m3, 0xFFFFC800) == countPixel(m3b, 0xFFFFC800));
+
+        System.out.println("Progresso: " + pass + " passaram, " + fail + " falharam");
+        System.exit(fail == 0 ? 0 : 1);
+    }
+
+    private static int countPixel(BufferedImage map, int rgb) {
+        int count = 0;
+        int w = map.getWidth();
+        int h = map.getHeight();
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                if (map.getRGB(x, y) == rgb) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+}

--- a/tools/rodada23_diagnostico_bugs.md
+++ b/tools/rodada23_diagnostico_bugs.md
@@ -1,0 +1,168 @@
+# Diagnóstico dos bugs reportados na rodada 23
+
+## Bug 1 — Telas sobrepostas (Game Over / Fase Concluída)
+
+Evidências das capturas do usuário:
+
+1. **Game Over**: "Game Over", "Voltando ao menu em...", "Pontuação final",
+   "Recorde", "Melhor combo da partida" e os botões aparecem DESALINHADOS
+   (texto grande branco em posições escaladas diferentes do botão azul),
+   sobre um cenário de fundo onde inimigos ainda estão visíveis e há uma
+   faixa "A Base Secreta de Nia" residual da missão — o mundo continua
+   renderizado com entidades atrás da tela de game over.
+
+2. **Fase Concluída**: o texto branco ("Fase 2 concluída!", "Tempo: 0:00",
+   "Próxima fase", "Missão: Defender o ponto", "Total acumulado", "Melhor
+   partida", "ENTER: continuar", "NOVO RECORDE GLOBAL") aparece DUPLICADO
+   — uma vez por cima do card e uma vez "solto" no fundo — porque a faixa
+   de transição (`showLevelTransition`) e o card `PhaseStatsScreen`
+   desenham textos com fontes/posições diferentes ao mesmo tempo, e a
+   fonte 36 do Game Over não é escalada pelo SCALE enquanto o resto usa
+   coordenadas escaladas.
+
+Causas raiz localizadas em `Game.render()`:
+
+- O bloco `GAMEOVER` usa `g.setFont(...)` (36/28/24/16 **sem multiplicar
+  pelo SCALE**) e coordenadas absolutas `scaledHeight/2+NN` em pixels de
+  janela — os textos ficam enormes/deslocados em relação ao botão azul
+  (`drawGameOverActions`) que é escalado corretamente.
+- `showLevelTransition > 0` desenha a faixa de conclusão **mesmo com o
+  `PhaseStatsScreen` visível** (o card chama `show()` e a faixa ainda está
+  ativa) → texto duplicado por trás do card.
+- `Enemy.enemies` (total da campanha) e `SaveManager.getBestRun...`
+  (melhor partida) aparecem juntos quando `Enemy.enemies > 0`, empurrando
+  o card; e `hidingHud` esconde a HUD de combate, mas o texto duplicado
+  vem da combinação faixa+card.
+
+Correção aplicada:
+
+1. Game Over: fontes multiplicadas pelo SCALE (`36*scale`, etc.) e
+   coordenadas no espaço do jogo escalado (em `unit = scale/4` ou
+   diretamente `... * scale`), consistentes com `drawGameOverActions`.
+2. Faixa `showLevelTransition`: suprimida quando o
+   `PhaseStatsScreen.isShowing()` estiver visível (o card é o resumo
+   oficial da fase concluída).
+3. Overlay do Game Over: manter o world renderizado atrás (cenário) mas
+   com o mesmo escurecimento; inimigos congelados já são suprimidos no
+   `isTransitioning()`/GAMEOVER? — verificar; se não, pular Enemy render
+   no GAMEOVER como no `questCompletedPending`.
+
+## Bug 2 — Música de ambiente só inicia ao carregar jogo
+
+Comportamento observado: `.\gradlew.bat run` → novo jogo → música não
+toca; só ao "Carregar jogo" ela começa.
+
+Suspeita principal: `MusicManager`/`SoundManager` só chama `play()` na
+rotina de `loadSlot()` (migração/restauração), e o novo jogo não
+aciona `SoundManager.play()` para a zona da fase 1. Verificar:
+
+- `MusicZoneManager` / zonas de música (MusicZoneTest) — a zona só
+  ativa quando o jogador anda pela fase (World.onPlayerMove?).
+- `loadSlot` → `SoundManager.play(...)` explícito.
+- `Game.startNewGame()` → checar se há chamada de música inicial.
+
+Correção: tocar a música da zona atual no `startNewGame`/`restartGame`
+(novo jogo e fase carregada), igual ao que o loadSlot faz.
+
+## Padrão para testes
+
+- `out=/tmp/test_X; rm -rf $out; mkdir -p $out; javac -d $out -cp bin:res tools/X.java 2>/dev/null && timeout 60 env DISPLAY=:120 java -cp $out:bin:res X 2>/dev/null | tail -1`
+- Builds: `find src -name "*.java" > /tmp/alljava.txt && xargs javac -d bin -cp bin < /tmp/alljava.txt`
+- Regressão (19 suítes): ObjectivesVariadosTest, ShopQaTest, MenuNavigationTest,
+  PhaseTransitionTest, AutoValidate, StoryNpcPlacementTest, WaypointFrameTest,
+  TransitionCooldownTest, MusicZoneTest, InventoryTest, BranchingNpcTest,
+  Rodada22bTest..22fTest, FaseSaveE2ETest, Rodada22g2Test, Rodada22g3Test.
+
+## Bug 2 — detalhes técnicos confirmados
+
+- `MusicManager.setZone(Zone.forLevel(1))` é chamado em `startNewGame()`
+  (linha 1501) e `advanceToNextLevel()` (linha 1718); `Zone.forLevel(1)`
+  = FOREST → path `music_forest.wav` (existe em res/sounds).
+- `setZone` → `load(path)` abre o Clip com `clip.loop(LOOP_CONTINUOUSLY)`
+  MAS `clip.start()` NÃO é chamado no load! O start vem do `startAt` no
+  update do crossfade (`if (!fadingIn.isRunning()) fadingIn.start()` no
+  update) — OK em teoria.
+- **Suspeita principal**: o crossfade (`update()`) só é chamado dentro do
+  `if ("NORMAL".equals(gameState))` (linha ~616) — e no novo jogo o
+  estado inicial é a SELEÇÃO DE ARMA INICIAL (`startInitialWeaponSelect()`)
+  com gameState não-NORMAL (MENU?), então `MusicManager.update()` não
+  roda → fadingIn nunca faz start → música nunca toca. Ao "carregar
+  jogo", o loadSlot cai direto em estado NORMAL → update roda → música
+  toca.
+- Teste a fazer: probe headless que cria Game → startNewGame → espera 3s
+  → verifica MusicManager.isMusicPlaying() (criar getter para teste).
+- Fix proposto: chamar `MusicManager.update()` em qualquer gameState
+  (ou iniciar música de forma imediata com startAt no setZone) e/ou
+  chamar setZone também ao entrar em estados de menu/menu inicial.
+
+## Paths zonas
+FOREST=music_forest.wav (nível 1-2), TENSION=music_tension.wav (3-5),
+BOSS=music_boss.wav (6+), ARENA=music_arena.wav. CROSSFADE_FRAMES=120 (~2s).
+
+## Bug 2 — status do fix (atualizado)
+
+Fix APLICADO no Game.java: `MusicManager.update()` movido para ANTES do
+bloco `if ("NORMAL".equals(gameState))` — roda em qualquer gameState.
+(Carregado no estado da sessão.)
+
+O probe Rodada23aMusicAndScreensTest.java mostra:
+- novo jogo inicia em MENU: PASS
+- crossfade iniciado (fadingIn != null) e música tocando: **FAIL** — o
+  jogo TRAVOU no probe (timeout 124), o loop de MusicManager.update()
+  provavelmente trava no AudioSystem quando não há servidor de som
+  (headless com pulse/PulseAudio ausente no sandbox → Clip.start() trava
+  o loop? Não, update roda no mesmo thread). Na verdade: startNewGame()
+  chamou setZone → load() → clip.open(ais) → pode THROWAR/travar quando
+  não há linha de áudio (Linux headless: Clip.open com linha indisponível
+  lança LineUnavailableException → catch Exception retorna null → setZone
+  retorna → fadingIn=null → loop do teste continua → deveria terminar em
+  300 iterações...). O teste NÃO terminou → travou em outro lugar:
+  provavelmente no NEW Game() constructor → new World() → Spritesheet →
+  áudio ou AWT. Verificar: travamento pode ser no `SoundManager.unload()`
+  ou no frame.init. IMPORTANTE: o teste NÃO travou no run anterior
+  (completou 8 checks) — agora travou no loop de música.
+
+Hipótese restante: `MusicManager.update()` chamado fora do bloco NORMAL
+roda também no GAMEOVER/MENU do teste e o `AudioSystem.getClip()` trava
+no sandbox headless SEM linha de áudio? startAt → clip.start() → no
+Linux headless sem PulseAudio o start pode bloquear?? Improvável.
+MAIS PROVÁVEL: o `new Game()` no probe trava DEPOIS de imprimir os
+checks estáticos (os checks 2-5 são grep no fonte, depois vem o loop de
+música). O loop: update() → load não é chamado de novo (zone já setada)
+→ crossfadeRemaining=120 → applyGain → setFramePosition... nada trava.
+A NÃO SER: o AudioSystem.getClip() dentro do load trava na PRIMEIRA
+chamada em linha sem mixer? Não — load roda UMA vez.
+→ Investigar: rodar probe com stacktrace (sem 2>/dev/null) e time.
+
+## Outros dados
+- res/: level1-8.png já existem (incl. level7/8!). Sounds: /sounds/*.wav
+  no classpath (build.gradle: main.java.srcDirs=['src','res'],
+  main.resources.srcDirs=['src','res']).
+- build.gradle usa Gradle com srcDirs res; testes headless usam -cp bin:res.
+
+## Bug 2 — causa raiz FINAL
+
+1. **O freeze do probe é SOLO-DO-SANDBOX**: `AudioSystem.getMixerInfo()` retorna 0
+   mixers (sem PulseAudio no sandbox). `AudioSystem.getClip()` lança
+   IllegalArgumentException → load() retorna null → crossfade não inicia.
+   No PC do usuário (Windows, PulseAudio/mixer presente) o clip funciona.
+2. **Mas o bug do usuário é REAL e está no Game.java**: `MusicManager.update()`
+   rodava APENAS dentro do gameState NORMAL. No novo jogo, o estado inicial
+   é MENU (seleção de arma) → o crossfade nunca era conduzido → música muda
+   até carregar um save (loadSlot vai direto ao estado NORMAL). FIX JÁ
+   APLICADO: update() chamado antes do bloco NORMAL, todos os gameStates.
+3. **Correções colaterais no MusicManager**: clampToFloor usa o mínimo do
+   FloatControl do próprio clip (controles variam -80..0 dB); o floor fixo
+   -60 dB foi removido da interpolação.
+4. No probe: como o sandbox não tem mixer, os checks de crossfade/música
+   só podem validar: zone atribuída + update roda fora do NORMAL + load não
+   trava o jogo (carregar em thread separada).
+
+## Status dos outros fixes (Game Over / transição)
+- Fontes proporcionais ao SCALE (unit=SCALE/4) no GAMEOVER: OK no fonte.
+- Faixa de transição suprimida com PhaseStatsScreen.isShowing(): OK.
+- Inimigos ocultos durante GAMEOVER: OK.
+- Probe Rodada23a: 6/8 PASS; 2 FAIL são o crossfade/música que dependem de
+  mixer real — no PC do usuário devem passar (o volume default é 0 dB/
+  normal). Verificar: getMusicVolume() retorna 0.0 → 0 dB = ganho máximo
+  da trilha (normal); no PC funciona.

--- a/tools/rodada24b_plano.md
+++ b/tools/rodada24b_plano.md
@@ -1,0 +1,27 @@
+# Rodada 24b — Elites procedurais + recorde de profundidade
+
+## 1. Elites procedurais (a partir da profundidade 3)
+Design (plano 24): inimigos de elite com vida/dano +30% e aura brilhante (visual).
+
+Implementação:
+- `Enemy.java`:
+  - campo `private final boolean elite` + parâmetro `boolean elite` nos 3 construtores (default false)
+  - construtor multiplica `maxLife` e `projectileDamage` por 1.3 quando elite; velocidade +5%
+  - `render(Graphics g)`: aura pulsante dourada quando elite (frame pares/desimpares, alpha ~150-220)
+- `ProceduralLevelGenerator.java`:
+  - nova cor `ELITE = (255, 200, 0)` — pixel amarelo-dourado
+  - `placeEntities`: rolagem dedicada — a partir de depth >= 3, parte dos slots de variante viram ELITE pixel; usar roll separado: `if (roll < 70) variante; else if (eliteEligible && eliteRoll) ELITE` — manter contagem de elites limitada: `eliteCount < 1 + depth/3`, total de entidades cap 20 (o pixel ELITE vira um inimigo randômico de variante não-boss com elite=true ao ser lido pela World)
+  - `validate`: aceitar rgb ELITE como entidade válida
+- `World.java` (applyMapPixels): novo caso `0xFFFFC800` → inimigo de variante aleatória não-boss com `elite=true` (escolher entre WARDEN/SENTINEL/RAVAGER/PHANTOM via rng do mapa — usar QuestManager/World RNG? Melhor: variante fixa determinada por posição para determinismo: (xx+yy)%4)
+  - IMPORTANTE: elite NÃO pode contar como chefe (`boss=false`) e não pode ser PHANTOM? O plano diz vida/dano +30%; PHANTOM drena — usar variantes sólidas: WARDEN, SENTINEL, RAVAGER, SCOUT. Excluir GUARDIAN/WARBRINGER/OVERSEER/PHANTOM (elite = tropas de choque)
+
+## 2. Recorde de profundidade (deepRecord)
+- `SaveManager.java` (v4): novo campo `deepRecord` por slot (int) + raiz `bestDeepRecord`
+  - Incrementar quando uma profundidade do modo infinito é COMPLETA (fases 1-8 completadas contam como campanha; recorde = maior profundidade alcançada no infinito)
+  - Atualizar em `advanceProceduralPhase` (Game.java) quando depth supera o recorde do slot; gravar em `saveGame`/autosave
+  - Exibir no menu principal abaixo das outras stats (linha "Recorde de Profundidade: N") — Menu.java handleMainMenuSelection/render do menu; usar a fonte/posição padrão do menu
+- Migração v3→v4: init 0
+- Testes: `Rodada24bEliteTest.java` (elite stats +30%, aura, não aparece antes de depth 3, não conta como chefe, valida mapa) e `Rodada24bDeepRecordTest.java` (record persiste entre sessões, aumenta com profundidade, só infinito, exibido no menu)
+
+## Regressão
+26 suítes anteriores + 2 novas = 28/28 verdes antes do commit.


### PR DESCRIPTION
## Rodada 24b

### Tropas de elite procedurais (a partir da profundidade 3)
- `Enemy`: novo status `elite` — vida, dano de projétil e dano de colisão +30%, aura dourada pulsante como sinal visual
- `ProceduralLevelGenerator`: pixel amarelo-dourado (`0xFFFFC800`) com cap progressivo (`1 + depth/3`), sem elites nas profundidades 1 e 2
- `World`: elite vira variante sólida determinística (Warden/Sentinel/Ravager/Scout por posição) — nunca conta como chefe
- Geração continua determinística por semente e a validação estrutural aceita o pixel de elite

### Recorde de profundidade por slot
- `SaveManager` v4: campo `deepRecord` persistido por slot (`saves.json`), atualizado em `enterInfiniteMode` e `advanceProceduralPhase`
- Restaurado no `loadSlot`, exibido na tela de carregar jogo (`Profundidades: N`), zerado em memória no `startNewGame` (gravação persiste)
- Não regride com profundidades menores e não re-grava sem avanço

### Testes
- `Rodada24bEliteTest` (15/15): stats +30%, aura, ausência antes da depth 3, cap, determinismo
- `Rodada24bDeepRecordTest` (13/13): persistência, não-regressão, restauração no load, reset no novo jogo
- Regressão completa: **28/28 suítes verdes** (~400 checks)