### PR TITLE
Rodada 27: pipeline de testes JUnit 5 no Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,17 @@
-apply plugin: 'java'
-apply plugin: 'application'
+plugins {
+    id 'java'
+    id 'application'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
 
 application {
     mainClass = 'com.traduvertgames.main.Game'
 }
+
 sourceSets {
     main.java.srcDirs = ['src','res']
     main.resources.srcDirs = ['src','res']
@@ -13,4 +21,28 @@ sourceSets {
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
+    options.compilerArgs += ['-Xlint:deprecation']
 }
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform('org.junit:junit-bom:5.11.4')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+test {
+    useJUnitPlatform()
+    // Os testes de jogo são headless: criam o `Game` sem janela.
+    jvmArgs '-Djava.awt.headless=false',
+            '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+        showStandardStreams = false
+    }
+}
+
+check.dependsOn test

--- a/tests/java/com/traduvertgames/test/CampaignBeaconTest.java
+++ b/tests/java/com/traduvertgames/test/CampaignBeaconTest.java
@@ -1,0 +1,180 @@
+package com.traduvertgames.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import com.traduvertgames.main.Game;
+import com.traduvertgames.main.SaveManager;
+import com.traduvertgames.quest.QuestManager;
+import com.traduvertgames.entities.QuestBeacon;
+import com.traduvertgames.dialogue.InteractiveNpc;
+import com.traduvertgames.dialogue.SupportNpcs;
+
+/**
+ * Rodada 27 — regressão das missões de campanha no pipeline JUnit 5.
+ *
+ * Reproduz os cenários que causaram os bugs das rodadas 25–26:
+ *  1. A missão do beacon da fase 2 avança o canal mesmo em mapas que não têm
+ *     o tile do beacon (o `onLevelLoaded` da rodada 26 recria o beacon
+ *     programático).
+ *  2. Conversar com a Engenheira Nia destrava a etapa de defesa do beacon.
+ *  3. Autosave + reload preservam a fase e o canal do beacon.
+ *  4. Estado salvo corrompido (sem coordenadas do beacon) é recuperado na
+ *     carga — fix da rodada 26, que impedia a missão de travar em
+ *     "Localize o beacon do setor".
+ *
+ * Dependências: `res/` no classpath e display X11 (`xvfb-run` em headless).
+ * Observação: os mapas de teste (`tools/generate_maps.py`) não contêm o tile
+ * do tile `0xFF66BB6A` (Engenheira Nia), então os testes criam a NPC
+ * manualmente — o `DialogueObjective` compara pelo nome exato, como no jogo.
+ */
+public class CampaignBeaconTest {
+
+	private Game game;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		GameTestFixture.cleanSaveFiles();
+		game = GameTestFixture.newIsolatedGame();
+		Game.SCALE = 4;
+	}
+
+	@AfterEach
+	void tearDown() {
+		GameTestFixture.cleanSaveFiles();
+	}
+
+	/**
+	 * Os mapas de QA (`generate_maps.py`) vêm com inimigos genéricos no
+	 * raio do beacon — invadem a zona e travam o canal. O cenário da rodada
+	 * 26 exige exatamente "zona limpa", então os invasores são removidos.
+	 */
+	private void clearInvaders() {
+		Game.entities.removeIf(o -> o instanceof com.traduvertgames.entities.Enemy);
+		Game.enemies.clear();
+	}
+
+	private QuestBeacon findBeacon() {
+		for (Object o : Game.entities) {
+			if (o instanceof QuestBeacon) {
+				return (QuestBeacon) o;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Conversa com a Nia. Como os mapas de QA não trazem a NPC, cria-se uma
+	 * instância com o nome exato usado pelo `DialogueObjective` da fase 2.
+	 */
+	private void talkToNia() {
+		InteractiveNpc nia = SupportNpcs.engineer(8 * 16, 6 * 16);
+		Game.entities.add(nia);
+		QuestManager.notifyDialogueFinished(nia);
+	}
+
+	private int channelOf() {
+		String state = QuestManager.serializeObjectiveState();
+		int idx = state.indexOf("CHANNEL=");
+		if (idx < 0) {
+			return -1;
+		}
+		String rest = state.substring(idx + "CHANNEL=".length());
+		int semi = rest.indexOf(';');
+		String value = semi >= 0 ? rest.substring(0, semi) : rest;
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException ex) {
+			return -1;
+		}
+	}
+
+	/** Cenário 1: a troca de fase 1 → 2 chega ao nível 2 com beacon criado. */
+	@Test
+	void phaseTwoLoadsObjective() {
+		GameTestFixture.advanceToLevel(2);
+		QuestManager.onLevelLoaded();
+		assertEquals(2, QuestManager.getCurrentLevel(),
+				"após advanceToNextLevel o nível corrente deve ser 2");
+		assertNotNull(findBeacon(),
+				"o beacon programático da fase 2 deve existir (mesmo com tile de parede)");
+	}
+
+	/** Cenário 2: o canal do beacon avança com a zona de defesa limpa. */
+	@Test
+	void beaconChannelAdvances() {
+		GameTestFixture.advanceToLevel(2);
+		QuestManager.onLevelLoaded();
+		clearInvaders();
+		assertNotNull(findBeacon(), "o beacon deve existir");
+		for (int i = 0; i < 90; i++) {
+			QuestManager.update();
+		}
+		assertTrue(channelOf() > 0,
+				"o canal do beacon deve avançar com a zona limpa, estado: "
+						+ QuestManager.serializeObjectiveState());
+	}
+
+	/** Cenário 3: conversar com a Nia destrava a etapa de defesa. */
+	@Test
+	void beaconStageUnlockedAfterDialogue() {
+		GameTestFixture.advanceToLevel(2);
+		QuestManager.onLevelLoaded();
+		String before = QuestManager.getObjectiveProgress();
+		assertTrue(before.contains("Fale"),
+				"antes da conversa o progresso pede o diálogo: " + before);
+
+		talkToNia();
+
+		String after = QuestManager.getObjectiveProgress();
+		assertFalse(after.contains("Fale"),
+				"após a conversa o diálogo não pode mais ser o pedido atual: "
+						+ after);
+		String state = QuestManager.serializeObjectiveState();
+		assertTrue(state.contains("TALKED=true"),
+				"o estado serializado deve marcar TALKED=true");
+	}
+
+	/** Cenário 4: autosave + reload preservam a fase e o canal do beacon. */
+	@Test
+	void reloadPreservesBeaconProgress() {
+		GameTestFixture.advanceToLevel(2);
+		QuestManager.onLevelLoaded();
+		clearInvaders();
+		talkToNia();
+		for (int i = 0; i < 90; i++) {
+			QuestManager.update();
+		}
+		int channelBefore = channelOf();
+		assertTrue(channelBefore > 0,
+				"o canal do beacon deve avançar com a zona limpa");
+
+		assertTrue(SaveManager.saveCurrentGame(), "autosave deve gravar");
+		assertTrue(SaveManager.loadSlot(SaveManager.activeSlot),
+				"reload do slot ativo deve restaurar a fase 2");
+		assertEquals(2, QuestManager.getCurrentLevel());
+		assertNotNull(findBeacon(), "o beacon deve existir após o reload");
+		assertEquals(channelBefore, channelOf(),
+				"o canal do beacon deve ser preservado pelo reload");
+	}
+
+	/** Cenário 5: estado salvo sem beacons (corrompido) é recuperado na carga. */
+	@Test
+	void corruptedSaveRecoversBeacon() throws Exception {
+		GameTestFixture.advanceToLevel(2);
+		QuestManager.onLevelLoaded();
+		assertTrue(SaveManager.saveCurrentGame(), "save deve gravar a fase 2");
+		GameTestFixture.corruptBeaconsInSave();
+
+		assertTrue(SaveManager.loadSlot(SaveManager.activeSlot),
+				"reload com beacons ausentes deve completar");
+		assertEquals(2, QuestManager.getCurrentLevel());
+		assertNotNull(findBeacon(),
+				"o beacon deve ser recriado mesmo com o save corrompido");
+		String progress = QuestManager.getObjectiveProgress();
+		assertNotEquals("Localize o beacon do setor", progress,
+				"o progresso não pode travar em 'Localize' após recuperação: "
+						+ progress);
+	}
+}

--- a/tests/java/com/traduvertgames/test/GameTestFixture.java
+++ b/tests/java/com/traduvertgames/test/GameTestFixture.java
@@ -1,0 +1,86 @@
+package com.traduvertgames.test;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import com.traduvertgames.main.Game;
+import com.traduvertgames.main.SaveManager;
+
+/**
+ * Fixture reutilizável para os testes de jogo (JUnit 5).
+ *
+ * Os testes instanciam o `Game` sem iniciar o loop de renderização — a janela
+ * é criada apenas para o loop de eventos AWT (display via `xvfb-run` no CI),
+ * mas `start()` nunca é chamado, então nada roda em 60 FPS e nenhum teste
+ * depende de tempo real.
+ *
+ * Requisitos para rodar:
+ *  - `res/` no classpath (spritesheets e mapas `level*.png`);
+ *  - JVM sem `-Djava.awt.headless=true` (o AWT precisa do X11 para métricas
+ *    de fontes e buffers de janela — o Gradle configura isso na tarefa `test`);
+ *  - em máquinas sem display físico, usar `xvfb-run ./gradlew test`.
+ */
+public final class GameTestFixture {
+
+	private GameTestFixture() {}
+
+	/** Arquivos voláteis que o jogo grava no diretório de trabalho. */
+	private static final String[] SCRATCH_FILES = {
+		"saves.json", "saves.backup.json", "save.txt"
+	};
+
+	/**
+	 * Remove arquivos de save do diretório de trabalho para isolar o teste.
+	 */
+	public static void cleanSaveFiles() {
+		for (String name : SCRATCH_FILES) {
+			new File(name).delete();
+		}
+	}
+
+	/**
+	 * Cria um `Game` isolado (menu em pausa, sem loop) e reseta o estado do
+	 * jogo para o padrão de novo jogo. O estado estático do `Game` precisa
+	 * passar por `startNewGame` para não carregar resquícios de testes
+	 * anteriores — mas `startNewGame` inicia o onboarding em
+	 * `training.png`, então esta fixture usa o caminho mais direto:
+	 * instancia o `Game` (estado MENU) e deixa o teste controlar o fluxo.
+	 */
+	public static Game newIsolatedGame() throws Exception {
+		cleanSaveFiles();
+		// O jogo carrega o spritesheet do classpath (`res/` precisa estar lá).
+		return new Game();
+	}
+
+	/**
+	 * Inicializa o ambiente mínimo exigido pelas classes de entidade:
+	 * `Entity.<clinit>` usa `Game.spritesheet`, então basta instanciar um
+	 * `Game` uma única vez (sem loop) antes dos testes de lógica pura
+	 * poderem criar `QuestItem`, `CommanderNpc`, `Enemy` e afins.
+	 */
+	public static Game initHeadless() throws Exception {
+		return new Game();
+	}
+
+	/**
+	 * Simula a troca de fase como o fluxo real do jogo (loja/level up fechados,
+	 * card de estatísticas exibido, mapa `levelN.png` carregado).
+	 */
+	public static void advanceToLevel(int targetLevel) {
+		while (Game.getCurrentLevel() < targetLevel && Game.getCurrentLevel() < Game.MAX_LEVEL) {
+			Game.advanceToNextLevel();
+		}
+	}
+
+	/**
+	 * Corrompe a lista de beacons no save ativo (remove coordenadas), simulando
+	 * o cenário em que o registro do beacon se perde entre fases.
+	 */
+	public static void corruptBeaconsInSave() throws Exception {
+		Path save = SaveManager.SAVE_FILE.toPath();
+		String text = new String(Files.readAllBytes(save), java.nio.charset.StandardCharsets.UTF_8);
+		text = text.replaceAll("BEACONS=[0-9,|]*", "BEACONS=");
+		Files.write(save, text.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+	}
+}

--- a/tests/java/com/traduvertgames/test/QuestObjectiveLogicTest.java
+++ b/tests/java/com/traduvertgames/test/QuestObjectiveLogicTest.java
@@ -1,0 +1,170 @@
+package com.traduvertgames.test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import com.traduvertgames.quest.ContactObjective;
+import com.traduvertgames.quest.SequenceObjective;
+import com.traduvertgames.quest.HoldObjective;
+import com.traduvertgames.quest.BossHuntObjective;
+import com.traduvertgames.quest.DialogueObjective;
+import com.traduvertgames.dialogue.CommanderNpc;
+import com.traduvertgames.dialogue.InteractiveNpc;
+import com.traduvertgames.dialogue.SupportNpcs;
+import com.traduvertgames.entities.Enemy;
+import com.traduvertgames.entities.QuestItem;
+import com.traduvertgames.quest.QuestManager;
+
+/**
+ * Rodada 27 — testes de lógica pura dos objetivos de missão (sem `Game`).
+ *
+ * Valida a composição `DialogueObjective` → `SequenceObjective` →
+ * `HoldObjective` → `BossHuntObjective` usada pela campanha (fases 2, 6 e 7)
+ * e a missão de contato da fase 1: cada etapa avança a próxima e o objetivo
+ * composto só completa quando todas concluem.
+ */
+public class QuestObjectiveLogicTest {
+
+	/**
+	 * Classes como `CommanderNpc` e `QuestItem` herdam `Entity`, cujo
+	 * inicializador carrega `Game.spritesheet` — sem essa instância, a
+	 * primeira construção de entidade falha com `NullPointerException`.
+	 */
+	@BeforeAll
+	static void initHeadlessEnvironment() throws Exception {
+		GameTestFixture.initHeadless();
+	}
+
+	/** Fase 1: conversa com a Comandante + 2 artefatos completam o contato. */
+	@Test
+	void contactObjectiveRequiresTalkAndArtifacts() {
+		ContactObjective contact = new ContactObjective();
+		assertFalse(contact.isComplete(), "não deve completar sem fala nem coleta");
+
+		InteractiveNpc ava = new CommanderNpc(0, 0);
+		contact.onDialogueFinished(ava);
+		assertFalse(contact.isComplete(), "fala sozinha não completa");
+
+		contact.onQuestItemCollected(new QuestItem(0, 0, java.awt.Color.ORANGE));
+		assertFalse(contact.isComplete(), "1 artefato + fala não completa");
+
+		contact.onQuestItemCollected(new QuestItem(0, 0, java.awt.Color.ORANGE));
+		assertTrue(contact.isComplete(), "2 artefatos + fala devem completar");
+	}
+
+	/** Fase 1: o progresso textual guia o jogador antes e depois da fala. */
+	@Test
+	void contactProgressTextGuidesPlayer() {
+		ContactObjective contact = new ContactObjective();
+		assertTrue(contact.getProgressText().contains("Fale"),
+				"progresso inicial deve pedir a conversa");
+		contact.onDialogueFinished(new CommanderNpc(0, 0));
+		assertTrue(contact.getProgressText().contains("Artefatos"),
+				"progresso pós-fala deve pedir os artefatos");
+	}
+
+/** Fase 2: hold (canal do beacon a 100%) + caça ao chefe em sequência. */
+	@Test
+	void holdThenBossSequence() {
+		HoldObjective hold = new HoldObjective();
+		BossHuntObjective boss = new BossHuntObjective();
+		SequenceObjective sequence = new SequenceObjective(hold, boss);
+
+		assertFalse(sequence.isComplete(), "sequência não inicia completa");
+		assertFalse(boss.isComplete(), "boss não inicia completo");
+		assertEquals(hold, sequence.getActive(), "a etapa ativa inicial é o hold");
+
+		// O hold completa quando o canal do beacon atinge 100% — simulado
+		// injetando o valor via reflexão (o avanço real depende de
+		// `update()` varrendo `Game.entities`, fora do escopo deste teste
+		// de lógica pura).
+		hold.onBeaconSpawned(new com.traduvertgames.entities.QuestBeacon(0, 0,
+				java.awt.Color.GREEN));
+		setChannelToMax(hold);
+		assertTrue(hold.isComplete(), "hold marcado como completo após o canal fechar");
+		// A troca para a próxima etapa só ocorre dentro de `update()`, quando
+		// `getActive().isComplete()` vira true — mesma semântica do jogo.
+		sequence.update();
+		assertFalse(sequence.isComplete(), "sequência aguarda o boss após o hold");
+		assertEquals(boss, sequence.getActive(),
+				"a etapa ativa avança para o boss após o update()");
+
+		boss.onLevelStart();
+		boss.registerBossPresence();
+		boss.onEnemyKilled(new Enemy(0, 0, 20, 20, null,
+				Enemy.Variant.WARBRINGER, true));
+		assertTrue(boss.isComplete(), "boss derrotado completa");
+		assertTrue(sequence.isComplete(), "sequência completa após ambas as etapas");
+	}
+
+/** Fase 2: o DialogueObjective só libera a sequência após a conversa. */
+	@Test
+	void dialogueObjectiveUnlocksSequence() {
+		BossHuntObjective boss = new BossHuntObjective();
+		HoldObjective hold = new HoldObjective();
+		SequenceObjective inner = new SequenceObjective(hold, boss);
+		DialogueObjective quest = new DialogueObjective(inner, "Engenheira Nia");
+
+		assertFalse(quest.isComplete(), "sem conversa a missão não completa");
+		assertFalse(quest.hasTalkedToTarget(), "nenhum diálogo ocorreu");
+
+		// Diálogo com NPC errado não marca o alvo (Nia é fabricada pelo SupportNpcs).
+		quest.onDialogueFinished(new CommanderNpc(0, 0));
+		assertFalse(quest.hasTalkedToTarget(), "diálogo com NPC errado não marca o alvo");
+
+		// Diálogo com a alvo correta completa a etapa de conversa.
+		quest.onDialogueFinished(SupportNpcs.engineer(0, 0));
+		assertTrue(quest.hasTalkedToTarget(), "diálogo com a Nia marca o alvo");
+		assertFalse(quest.isComplete(), "diálogo completo, mas hold/boss pendentes");
+
+		hold.onBeaconSpawned(new com.traduvertgames.entities.QuestBeacon(0, 0,
+				java.awt.Color.GREEN));
+		setChannelToMax(hold);
+		assertFalse(quest.isComplete(), "falta o boss");
+
+		// Mesma semântica do jogo: `update()` avança as etapas e
+		// `onEnemyKilled` do boss (via QuestManager) marca a derrota.
+		boss.onLevelStart();
+		boss.registerBossPresence();
+		boss.onEnemyKilled(new Enemy(0, 0, 20, 20, null,
+				Enemy.Variant.OVERSEER, true));
+		// A troca da etapa ativa acontece dentro de `update()` da sequência
+		// (o wrapper não está no QuestManager real neste teste de lógica
+		// pura, então o ciclo é fechado manualmente na instância local).
+		inner.update();
+		assertTrue(quest.isComplete(), "tudo completo: missão encerrada");
+	}
+
+	private static void setChannelToMax(HoldObjective hold) {
+			try {
+				java.lang.reflect.Field channelField =
+						HoldObjective.class.getDeclaredField("channel");
+				channelField.setAccessible(true);
+				java.lang.reflect.Field maxField =
+						HoldObjective.class.getDeclaredField("CHANNEL_MAX");
+				maxField.setAccessible(true);
+				channelField.set(hold, maxField.getInt(null));
+			} catch (Exception ex) {
+				throw new RuntimeException("não foi possível simular o canal",
+						ex);
+			}
+		}
+
+	/** Serialização preserva o estado do ContactObjective. */
+	@Test
+	void contactObjectiveSerializeRoundTrip() {
+		ContactObjective contact = new ContactObjective();
+		contact.onDialogueFinished(new CommanderNpc(0, 0));
+		contact.onQuestItemCollected(new QuestItem(0, 0, java.awt.Color.ORANGE));
+
+		String state = contact.serializeState();
+		assertTrue(state.contains("TALKED=true"), "estado deve marcar a fala");
+		assertTrue(state.contains("ARTIFACTS=1"), "estado deve marcar 1 artefato");
+		assertFalse(state.equals("COMPLETE"), "estado parcial não pode ser COMPLETE");
+
+		ContactObjective restored = new ContactObjective();
+		restored.deserializeState(state);
+		assertEquals(state, restored.serializeState(),
+				"round-trip de serialização deve ser idempotente");
+	}
+}


### PR DESCRIPTION
## Rodada 27 — Fundamentos de teste

Configura o pipeline de testes JUnit 5 no Gradle e migra os testes headless de `tools/` para `tests/java`, com foco nas transições de maior risco que causaram os bugs das rodadas 25–26 (beacon travado, mobs ressuscitando).

### O que mudou
- **`build.gradle`**: plugins block, Java 11 target, JUnit 5.11.4 (BOM + `junit-platform-launcher`), tarefa `test` com `useJUnitPlatform()`, `headless=false` e `--add-opens java.base/java.lang`. `check.dependsOn test`.
- **`tests/java/com/traduvertgames/test/`**:
  - `GameTestFixture.java` — fixture reutilizável: isolamento de saves, `advanceToLevel`, corrupção de beacons no save e init headless mínimo.
  - `CampaignBeaconTest.java` — regressão das rodadas 25–26: fase 2 com beacon programático, canal avança com zona limpa, diálogo da Engenheira Nia destrava a etapa, reload preserva o canal do beacon, save corrompido (sem beacons) é recuperado na carga.
  - `QuestObjectiveLogicTest.java` — lógica pura da composição `DialogueObjective > SequenceObjective > HoldObjective > BossHuntObjective` (fases 2, 6 e 7), missão de contato da fase 1 e round-trip de serialização de estado.

### Como rodar
```bash
./gradlew test        # suíte completa
./gradlew check       # check depende de test
```
Em máquinas sem display físico, usar `xvfb-run ./gradlew test` (o AWT precisa de X11 para métricas de fontes/buffers).

### Resultado
- 10 testes, todos passando.
- Observação: os testes rodam em Linux; no Windows sem display, adicionar `xvfb-run` ou equivalente (o Gradle não precisa de mais nada além da JVM 11+).
